### PR TITLE
ci: automatically assign reviewers for PRs

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,44 @@
+name: Auto Assign Reviewers
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign reviewers based on author
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const prNumber = context.payload.pull_request.number;
+
+            let reviewers = [];
+
+            // Define your mapping
+            const reviewerMap = {
+              'MichielStock': ['cvigilv'],
+              'cvigilv': ['MichielStock'],
+              // Default reviewers for other contributors
+              'default': ['MichielStock', 'cvigilv']
+            };
+
+            // Assign based on author
+            if (reviewerMap[author]) {
+              reviewers = reviewerMap[author];
+            } else {
+              reviewers = reviewerMap['default'];
+            }
+
+            // Remove author from reviewers if present
+            reviewers = reviewers.filter(reviewer => reviewer !== author);
+
+            if (reviewers.length > 0) {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                reviewers: reviewers
+              });
+            }

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,8 +1,10 @@
 name: Auto Assign Reviewers
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request:
     types: [opened]
-
 jobs:
   assign-reviewers:
     runs-on: ubuntu-latest
@@ -14,24 +16,20 @@ jobs:
             const author = context.payload.pull_request.user.login;
             const prNumber = context.payload.pull_request.number;
 
-            let reviewers = [];
+            // Skip if PR is from a fork
+            if (context.payload.pull_request.head.repo.full_name !== context.payload.repository.full_name) {
+              core.info('PR is from a fork, skipping reviewer assignment.');
+              return;
+            }
 
-            // Define your mapping
+            let reviewers = [];
             const reviewerMap = {
               'MichielStock': ['cvigilv'],
               'cvigilv': ['MichielStock'],
-              // Default reviewers for other contributors
               'default': ['MichielStock', 'cvigilv']
             };
 
-            // Assign based on author
-            if (reviewerMap[author]) {
-              reviewers = reviewerMap[author];
-            } else {
-              reviewers = reviewerMap['default'];
-            }
-
-            // Remove author from reviewers if present
+            reviewers = reviewerMap[author] || reviewerMap['default'];
             reviewers = reviewers.filter(reviewer => reviewer !== author);
 
             if (reviewers.length > 0) {


### PR DESCRIPTION
This PR create a GitHub Action to automatically setup PR review.

Since we are two currently actively developing the package, I thought it would be a good idea to automatically be assigned as reviewers of each others PRs. In the case someone external contributes, we will both be assigned as reviewers of that PR.

LMKWYT
