### PR TITLE
fix: make BinaryHV/BipolarHV bundling deterministic

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -91,13 +91,23 @@ end
 # ------
 
 # binary and bipolar: use majority
-function bundle(hvr::Union{BinaryHV, BipolarHV}, hdvs, r)
+#
+# When an even number of hypervectors is bundled, positions with an equal number
+# of votes for each state are ties that have to be resolved. To keep bundling
+# deterministic (identical inputs always yield the same result) while avoiding
+# the positional bias a fixed per-index rule would introduce, ties are broken
+# with a local RNG seeded from the aggregated votes `r`, which depends on every
+# input hypervector. Pass `rng` to override the seed (e.g. reproducible draws
+# from a caller-controlled stream), or `rng = Random.default_rng()` to recover
+# the previous, non-deterministic behaviour.
+function bundle(hvr::Union{BinaryHV, BipolarHV}, hdvs, r; rng::Union{Nothing, AbstractRNG} = nothing)
     m = length(hdvs)
     for hv in hdvs
         r .+= hv.v
     end
     if iseven(m)  # break ties
-        r .+= bitrand(length(r))
+        tie_rng = isnothing(rng) ? Xoshiro(hash(r)) : rng
+        r .+= bitrand(tie_rng, length(r))
     end
     hvr = similar(hvr)
     hvr.v .= r .> m / 2
@@ -152,7 +162,7 @@ end
 function bundle(hdvs; kwargs...)
     hv = first(hdvs)
     r = empty_vector(hv)
-    return bundle(hv, hdvs, r, kwargs...)
+    return bundle(hv, hdvs, r; kwargs...)
 end
 
 Base.:+(hv1::HV, hv2::HV) where {HV <: AbstractHV} = bundle((hv1, hv2))

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -24,6 +24,19 @@ Random.seed!(42)
                 @test bundle([hv1, hv2]) isa HV
                 @test bundle((HV(N) for i in 1:5)) isa HV
                 @test hv1 + hv2 isa HV
+
+                # Bundling must be deterministic for identical inputs, including
+                # the even-count tie-breaking case (see issue #47).
+                if HV <: Union{BinaryHV, BipolarHV}
+                    @test (hv1 + hv2).v == (hv1 + hv2).v
+                    @test bundle([hv1, hv2]).v == bundle([hv1, hv2]).v
+                    # even count -> ties are broken; odd count -> no ties
+                    hv3 = HV(; D = N)
+                    @test bundle([hv1, hv2, hv3]).v == bundle([hv1, hv2, hv3]).v
+                    # a caller-supplied rng reproduces its own draws
+                    @test bundle([hv1, hv2]; rng = MersenneTwister(1)).v ==
+                        bundle([hv1, hv2]; rng = MersenneTwister(1)).v
+                end
             end
 
             @testset "bind $HV" begin


### PR DESCRIPTION
Break even-count vote ties with a local RNG seeded from the aggregated votes (hash(r)) instead of the global RNG, so identical inputs always bundle to the same result while remaining unbiased across positions. Add an `rng` kwarg to override the seed, and fix keyword forwarding in the bundle dispatcher.

Closes #47