### PR TITLE
fix: correct `+` call

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -165,7 +165,7 @@ function bundle(hdvs; kwargs...)
     return bundle(hv, hdvs, r; kwargs...)
 end
 
-Base.:+(hv1::HV, hv2::HV) where {HV <: AbstractHV} = bundle((hv1, hv2))
+Base.:+(u::HV, v::AbstractArray...) where {HV <: AbstractHV} = bundle((u, v...))
 
 # BINDING
 # -------

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -22,18 +22,16 @@ Random.seed!(42)
             @testset "bundle $HV" begin
                 @test bundle((hv1, hv2)) isa HV
                 @test bundle([hv1, hv2]) isa HV
-                @test bundle((HV(N) for i in 1:5)) isa HV
+                @test bundle((HV(i; D = N) for i in 1:5)) isa HV
                 @test hv1 + hv2 isa HV
+                @test +((HV(i; D = N) for i in 1:5)...) isa HV
+                @test +((HV(i; D = N) for i in 1:5)...) == bundle((HV(i; D = N) for i in 1:5))
 
-                # Bundling must be deterministic for identical inputs, including
-                # the even-count tie-breaking case (see issue #47).
                 if HV <: Union{BinaryHV, BipolarHV}
                     @test (hv1 + hv2).v == (hv1 + hv2).v
                     @test bundle([hv1, hv2]).v == bundle([hv1, hv2]).v
-                    # even count -> ties are broken; odd count -> no ties
                     hv3 = HV(; D = N)
                     @test bundle([hv1, hv2, hv3]).v == bundle([hv1, hv2, hv3]).v
-                    # a caller-supplied rng reproduces its own draws
                     @test bundle([hv1, hv2]; rng = MersenneTwister(1)).v ==
                         bundle([hv1, hv2]; rng = MersenneTwister(1)).v
                 end
@@ -42,7 +40,9 @@ Random.seed!(42)
             @testset "bind $HV" begin
                 @test bind(hv1, hv2) isa HV
                 @test bind([hv1, hv2]) isa HV
-                @test bind([HV(N) for i in 1:5]) isa HV
+                @test bind([HV(i; D = N) for i in 1:5]) isa HV
+                @test *([HV(i; D = N) for i in 1:5]...) isa HV
+                @test bind([HV(i; D = N) for i in 1:5]) == *([HV(i; D = N) for i in 1:5]...) isa HV
                 @test hv1 * hv2 isa HV
             end
 


### PR DESCRIPTION
Previously, whenever one called `+` over more than 2 hypervectors, the operation worked at each pair, that is:

```
a + b + c + d +e = ((((a + b) + c) + d) + e)
```

This behavior breaks the binary hypervectors because, at each step, it introduces noise whenever there is a tie. This fix rewrites the `+` overload to correctly call the `bundle` function with an array of hypervectors rather than performing pairwise operations. Added some tests to cover this behavior.