### PR TITLE
Refactor july

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,32 @@ jobs:
       uses: julia-actions/julia-runtest@v1
 
     # TODO: Add coverage analysis and style checker
+
+  doctests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Julia
+      uses: julia-actions/setup-julia@v2
+      with:
+        version: '1'
+
+    - name: Cache Julia packages
+      uses: julia-actions/cache@v2
+
+    - name: Run doctests
+      run: |
+        julia --project=docs -e '
+          using Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()
+          using Documenter, HyperdimensionalComputing
+          DocMeta.setdocmeta!(
+              HyperdimensionalComputing,
+              :DocTestSetup,
+              :(using HyperdimensionalComputing, Distributions; using Random: Xoshiro);
+              recursive = true
+          )
+          doctest(HyperdimensionalComputing)'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ src/
   HyperdimensionalComputing.jl  # Main module, exports
   types.jl                      # AbstractHV and 7 concrete vector types
   operations.jl                 # bundle, bind, unbind, shift, perturbate
-  encoding.jl                   # Composite encoding strategies (ngrams, hashtable, etc.)
+  encoding.jl                   # Combinators (ngrams, hashtable, ...): hypervectors in, hypervector out
+  encode.jl                     # Encoder layer: raw data in, hypervector out (encode + strategies)
   inference.jl                  # similarity, nearest_neighbor
   representations.jl            # Custom show/display methods
 ext/
@@ -33,18 +34,23 @@ docs/
 | Type | Elements | Algebra | Key trait |
 |------|----------|---------|-----------|
 | `BinaryHV` | {false, true} (`Bool`, displays as 0/1) | BSC (Binary Spatter Codes) | BitVector storage |
-| `BipolarHV` | {-1, +1} | MAP (Multiply-Add-Permute) | BitVector storage; bit `true ↦ -1`, `false ↦ +1`, so XOR on stored bits IS the ±1 product. Construction from reals is sign-based; **zero elements throw** (use `TernaryHV`); Bool vectors are raw bits |
+| `BipolarHV` | {-1, +1} | MAP (Multiply-Add-Permute) | BitVector storage; bit `true ↦ -1`, `false ↦ +1`, so XOR on stored bits IS the ±1 product. Data must be exactly ±1; **zero elements throw** (use `TernaryHV`); Bool vectors are raw bits |
 | `TernaryHV` | {-1, 0, +1} | MAP variant | Vector{Int} |
 | `RealHV` | ℝ | Continuous MAP | Configurable distribution |
 | `GradedHV` | [0, 1] | Fuzzy logic | Beta distribution default |
 | `GradedBipolarHV` | [-1, 1] | Fuzzy logic bipolar | Scaled Beta default |
 | `FHRR` | Complex unit circle | Fourier HRR | e^(iθ) elements, supports `^` |
 
-Default dimension is 10,000 for all types. Constructor convention (settled; documented on `AbstractHV`):
+Default dimension is 10,000 for all types. Layer taxonomy: **primitives** (operations.jl: bundle/bind/shift/perturbate) → **combinators** (encoding.jl: multiset, ngrams, ... — hypervectors in, hypervector out) → **encoders** (encode.jl: raw data in, hypervector out).
+
+Constructor convention (settled; each form has exactly one meaning, documented on `AbstractHV`):
 
 - `HV(; D = 10_000, seed = nothing, rng = Random.default_rng())` — random; `rng` takes an `AbstractRNG` **instance**, `seed` builds a fresh `Xoshiro(seed)`
-- `HV(this; D = 10_000)` — deterministic token encoding via `Xoshiro(hash(this))`; the positional argument is **never** a dimension (an `Integer` triggers a one-time warning)
-- `HV(v::AbstractVector)` — wrap existing data
+- `HV(v::AbstractVector{<:Real})` — wrap element data, **validated** against the type's domain (BinaryHV {0,1}; BipolarHV ±1, zero errors pointing to TernaryHV; TernaryHV {-1,0,+1}; Graded types range-checked; FHRR unit modulus). Invalid arrays throw — they never silently token-encode
+- `HV(x)` — token shorthand for `encode(HV, x)`; `HV(n::Number)` **throws an ArgumentError** naming both alternatives (`D = n` / `encode(HV, n)`) — this replaced the old one-time `@warn`
+- Tuples of reals read as data, like vectors
+
+`encode` is the canonical interface: `encode(HV, x; D)` is the deterministic token path (hash → seed), `encode(HV, x, strategy)` dispatches on `AbstractEncoding` strategies: `KMer(k)` (windows as atomic hashed tokens — resolves issue #53), `NGram(n)` (symbol-level shift-binding via `ngrams`), `Sequence()` (bundlesequence), `BagOfSymbols()` (multiset). New strategies = one struct + one `encode` method. Planned follow-up: stateful `AbstractEncoder{HV}` structs (RandomProjection, LevelEncoder) with `encode`/`decode`.
 
 Scalar `getindex` returns the element type `T`; non-scalar indexing returns a plain `Vector` of values, never a hypervector. Hypervectors are immutable (no `setindex!`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,180 @@
+# CLAUDE.md - HyperdimensionalComputing.jl
+
+## What is this package?
+
+HyperdimensionalComputing.jl is a Julia package implementing Vector Symbolic Architectures (VSA) for hyperdimensional computing. HDC represents information as high-dimensional vectors (typically D=10,000) where three core operations — **bundling** (aggregation/superposition), **binding** (association/conjunction), and **permutation** (shifting) — are composed to encode arbitrary data structures. The high dimensionality guarantees that random vectors are quasi-orthogonal, enabling robust distributed representations.
+
+## Authors
+
+Carlos Vigil-Vásquez, Dimi Boeckaerts, Michiel Stock, Steff Taelman
+
+## Project structure
+
+```
+src/
+  HyperdimensionalComputing.jl  # Main module, exports
+  types.jl                      # AbstractHV and 7 concrete vector types
+  operations.jl                 # bundle, bind, unbind, shift, perturbate
+  encoding.jl                   # Composite encoding strategies (ngrams, hashtable, etc.)
+  inference.jl                  # similarity, nearest_neighbor
+  representations.jl            # Custom show/display methods
+ext/
+  UnicodePlotting.jl            # Extension for histogram/heatmap display via UnicodePlots
+test/
+  runtests.jl                   # Test runner
+  types.jl, operations.jl, encoding.jl, inference.jl, representations.jl
+  ext_display.jl                # rich-display tests, run in a separate process (extension loading is irreversible)
+docs/
+  src/examples/                 # Literate.jl tutorials (intro-to-hdc, dollar-of-mexico)
+```
+
+## Supported vector types (all subtypes of `AbstractHV{T} <: AbstractVector{T}`)
+
+| Type | Elements | Algebra | Key trait |
+|------|----------|---------|-----------|
+| `BinaryHV` | {false, true} (`Bool`, displays as 0/1) | BSC (Binary Spatter Codes) | BitVector storage |
+| `BipolarHV` | {-1, +1} | MAP (Multiply-Add-Permute) | BitVector storage; bit `true ↦ -1`, `false ↦ +1`, so XOR on stored bits IS the ±1 product. Construction from reals is sign-based; **zero elements throw** (use `TernaryHV`); Bool vectors are raw bits |
+| `TernaryHV` | {-1, 0, +1} | MAP variant | Vector{Int} |
+| `RealHV` | ℝ | Continuous MAP | Configurable distribution |
+| `GradedHV` | [0, 1] | Fuzzy logic | Beta distribution default |
+| `GradedBipolarHV` | [-1, 1] | Fuzzy logic bipolar | Scaled Beta default |
+| `FHRR` | Complex unit circle | Fourier HRR | e^(iθ) elements, supports `^` |
+
+Default dimension is 10,000 for all types. Constructor convention (settled; documented on `AbstractHV`):
+
+- `HV(; D = 10_000, seed = nothing, rng = Random.default_rng())` — random; `rng` takes an `AbstractRNG` **instance**, `seed` builds a fresh `Xoshiro(seed)`
+- `HV(this; D = 10_000)` — deterministic token encoding via `Xoshiro(hash(this))`; the positional argument is **never** a dimension (an `Integer` triggers a one-time warning)
+- `HV(v::AbstractVector)` — wrap existing data
+
+Scalar `getindex` returns the element type `T`; non-scalar indexing returns a plain `Vector` of values, never a hypervector. Hypervectors are immutable (no `setindex!`).
+
+## Core operations
+
+| Operation | Function | Operator | Effect |
+|-----------|----------|----------|--------|
+| Bundle | `bundle(hvs)` | `+` | Superposition; result similar to all inputs |
+| Bind | `bind(hv1, hv2)` | `*` | Association; result dissimilar to inputs |
+| Unbind | `unbind(hv1, hv2)` | `/` | Inverse of bind (throws for `RealHV`: real MAP binding is not exactly invertible) |
+| Shift | `shift(hv, k)` / `ρ(hv, k)` | — | Circular shift by k positions |
+| Perturbate | `perturbate(hv, n_or_p)` | — | Flip n positions or fraction p |
+
+In-place variants: `shift!`, `ρ!`, `perturbate!`.
+
+## Encoding strategies (compose primitives into structured representations)
+
+- `multiset(hvs)` — bundle a set of vectors
+- `multibind(hvs)` — bind a set of vectors
+- `bundlesequence(hvs)` / `bindsequence(hvs)` — ordered sequences via shift
+- `hashtable(keys, values)` — key-value pairs via bind+bundle
+- `crossproduct(U, V)` — cross product of two sets
+- `ngrams(hvs, n)` — n-gram statistics for text/sequence encoding
+- `graph(sources, targets)` — directed/undirected graph encoding
+- `level(hv, n)` / `encodelevel` / `decodelevel` / `convertlevel` — numeric level encoding
+
+## Similarity and inference
+
+- `similarity(u, v)` / `δ(u, v)` — type-dispatched similarity (cosine for bipolar/real, Jaccard for binary/graded, complex dot for FHRR)
+- `nearest_neighbor(u, collection)` — find closest match
+- `nearest_neighbor(u, collection, k)` — k-nearest neighbors
+
+## Dependencies
+
+Core: Distributions, LinearAlgebra, Random
+Optional: UnicodePlots (extension for REPL visualization)
+Julia compat: >= 1.11
+
+## Code style
+
+Uses [Runic.jl](https://github.com/fredrikekre/Runic.jl) formatter. Contributions follow GitHub Flow.
+
+## Running tests
+
+```bash
+julia --project -e 'using Pkg; Pkg.test()'
+```
+
+## Landscape: related packages
+
+**Python**: Torchhd (PyTorch-based, GPU-accelerated, most popular), OpenHD, hdlib, HDTorch, PyBHV, NengoSPA (HRR-based)
+**MATLAB**: VSA_Toolbox (TU Chemnitz)
+**Java**: Semantic Vectors
+
+## Key HDC/VSA concepts for contributors
+
+- **Blessing of dimensionality**: random vectors in D~10,000 are quasi-orthogonal with high probability
+- **Binding is self-inverse** for BSC/MAP (x * x = identity); FHRR unbinds exactly via elementwise complex division; RealHV binding is **not** exactly invertible (`unbind` throws)
+- **Bundle preserves similarity** to inputs; bind produces dissimilar output
+- **Shift encodes position** — used for sequences and n-grams
+- All encodings are compositions of these three primitives
+- The specific vector algebra matters less than the high dimensionality
+
+---
+
+## Issues and improvement backlog
+
+### 1. Code style issues
+
+- [x] ~~Typo "Represenetations" in FHRR comment and docstring~~ (fixed)
+- [x] ~~Missing blank line between TernaryHV and BinaryHV sections~~ (fixed)
+- [x] ~~TODO block references "complex HDC" which is now implemented (FHRR)~~ (fixed)
+- [x] ~~BinaryHV docstring says "A ternary hypervector type"~~ (fixed)
+- [x] ~~Stale comment about LazyArrays in `operations.jl`~~ (fixed)
+- [x] ~~Typo "Measurures" in `isapprox` docstrings~~ (fixed)
+- [x] ~~Typo "N_bootstap" in `isapprox` docstring~~ (fixed)
+- [x] ~~`predictors.jl` contains Dutch comments and dead code~~ (deleted)
+- [x] ~~Unused `counts` variable in `representations.jl` show method~~ (fixed)
+- [x] ~~Unused `counts` variable in `ext/UnicodePlotting.jl` show method~~ (fixed)
+- [x] ~~`docs/src/index.md` placeholder text "provides..."~~ (filled in)
+- [x] ~~`docs/src/index.md` and README link to wrong repo owner~~ (fixed)
+- [x] ~~`introduction-to-hdc.jl` uses undeclared `Handcalcs` dependency~~ (removed)
+- [x] ~~Typos "constituyents" / "contituyent" in introduction tutorial~~ (fixed)
+- [x] ~~`scripts/concept.jl` uses entirely obsolete API~~ (deleted)
+- [x] ~~`test/benchmarking.jl` uses entirely obsolete API~~ (deleted)
+- [x] ~~TernaryHV docstring says elements in `(-1, 1)` (open interval)~~ (fixed to `{-1, +1}`)
+- [x] ~~Graph docstring uses `\otimes` for outer op instead of `\oplus`~~ (fixed)
+- [x] ~~Typo "incoding" in `convertlevel` docstring~~ (fixed)
+
+### 2. Missing documentation
+
+- [x] ~~`AbstractHV`: no docstring on the abstract type itself~~ (added, documents the `HV(this; D, seed/rng)` constructor convention)
+- [x] ~~`BipolarHV`: no docstring~~ (added)
+- [x] ~~`RealHV`: no docstring~~ (added)
+- [x] ~~`GradedHV`: no docstring~~ (added)
+- [x] ~~`GradedBipolarHV`: no docstring~~ (added)
+- [x] ~~`FHRR`: no docstring~~ (added)
+- [x] ~~`bundle`: no docstring for any of the bundle methods~~ (added on the collection entry point)
+- [x] ~~`bind`: no docstring (only `unbind` has one)~~ (added)
+- [ ] `shift` / `ρ`: no docstrings
+- [ ] `perturbate` / `perturbate!`: no docstrings
+- [ ] `level`: docstring is minimal; does not explain the perturbation-based correlation mechanism
+- [ ] `three_pi` and `fuzzy_xor` helper functions: no docstrings
+- [ ] Internal functions (`aggfun`, `bindfun`, `neutralbind`, `noisy_and`, `elementreduce!`, `offsetcombine`, `empty_vector`, `eldist`, `vectype`): none documented
+- [ ] `docs/make.jl`: Contents block references `examples.md` but actual pages are in `examples/` subdirectory
+- [ ] No docstring for `^` on FHRR — exponentiation is an important FHRR feature
+- [ ] No developer docs on how to add a new HV type (what methods to implement, traits, etc.)
+
+### 3. Missing or incomplete features
+
+- [x] ~~`learning.jl`: commented out, uses old API~~ (deleted)
+- [x] ~~`predictors.jl`: uses undefined `cosine_dist`, empty Naive Bayes stub~~ (deleted)
+- [x] ~~`Distances` dependency declared but never used~~ (removed)
+- [x] ~~`convertlevel` passes `kwargs...` as positional to `decodelevel`~~ (fixed)
+- [x] ~~`BipolarHV` seed type inconsistent (`Number` vs `Integer`)~~ (fixed)
+- [x] ~~`GradedHV.similar` loses custom distribution~~ (fixed)
+- [ ] `SparseHV`: listed as TODO in `types.jl` — never implemented
+- [x] ~~`TernaryHV` constructor generates only ±1 — undocumented~~ (documented in docstring)
+- [x] ~~No `setindex!` on `AbstractHV` — undocumented~~ (documented on `AbstractHV`)
+- [ ] FHRR `unbind` uses element-wise `/` instead of idiomatic complex conjugate multiplication (works and is tested; conjugate variant is a possible refinement)
+- [x] ~~`empty_vector` not defined for FHRR — `bundle` would error~~ (stale: the generic `zero(hv.v)` fallback covers FHRR; bundle works and is tested)
+- [x] ~~`perturbate` not implemented for FHRR~~ (phase-resampling methods added)
+- [x] ~~`graph` docstring has empty `# Example` section~~ (example added)
+- [ ] No CI coverage analysis (`test.yml` has a TODO for this)
+- [x] ~~`StatsBase` dependency unused in `src/`~~ (removed from deps; `mean`/`std` come from the Distributions re-export)
+- [ ] No classification/learning workflow (`train`/`predict`) — HDC's main practical use case
+- [ ] Package not registered in Julia General registry
+
+### 4. Explicit TODOs in codebase
+
+- [ ] `src/types.jl`: `TODO: SparseHV`
+- [ ] `src/encoding.jl`: `# TODO: This should be bundled without normalizing` in `crossproduct`
+- [ ] `.github/workflows/test.yml`: `# TODO: Add coverage analysis and style checker`

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [weakdeps]
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
@@ -19,13 +18,13 @@ UnicodePlotting = "UnicodePlots"
 Distributions = "0.25.120"
 LinearAlgebra = "1.11.0"
 Random = "1.11.0"
-StatsBase = "0.34.6"
 UnicodePlots = "3.8.1"
 julia = "1.11"
 
 [extras]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["Logging", "Test"]
+test = ["Logging", "Test", "UnicodePlots"]

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,8 @@ UnicodePlots = "3.8.1"
 julia = "1.11"
 
 [extras]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Logging", "Test"]

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ y = BipolarHV(; D = 64)                           # dimensionality is set with t
 z = TernaryHV([1, 1, -1, 0, 0, 0, 1, 1, -1, 0])   # wrap an existing vector
 ```
 
-The positional argument is reserved for *the object you want to encode*: `HV(this)` returns
-the deterministic hypervector representing `this`, seeded by `hash(this)`. Any token — a
-symbol, string, character, number — gets its own reproducible, quasi-orthogonal hypervector:
+`encode(HV, x)` turns any object into a deterministic hypervector (seeded by `hash(x)`), and
+`HV(x)` is shorthand for it. Any token — a symbol, string, or character — gets its own
+reproducible, quasi-orthogonal hypervector:
 
 ```julia
 julia> cat = BipolarHV(:cat)
@@ -78,8 +78,17 @@ julia> similarity(cat, BipolarHV(:dog))  # different objects are quasi-orthogona
 ```
 
 > [!IMPORTANT]
-> The positional argument is never a dimension: `BinaryHV(6)` is the 10,000-dimensional
-> hypervector *encoding the number 6*. Use `BinaryHV(; D = 6)` to set the dimensionality.
+> A number is never a dimension — and never a constructor token: `BinaryHV(6)` throws,
+> because it is ambiguous. Use `BinaryHV(; D = 6)` for a 6-dimensional random hypervector,
+> or `encode(BinaryHV, 6)` to encode the number 6 as a token.
+
+Sequences are encoded through `encode` with a strategy — thin compositions of the
+combinators below:
+
+```julia
+dna = encode(BinaryHV, "ACGTGGCTA", KMer(3))      # k-mer profile: substrings as atomic tokens
+txt = encode(BinaryHV, "hello world", NGram(3))   # symbol-level n-grams via shift-binding
+```
 
 ### Operations
 

--- a/README.md
+++ b/README.md
@@ -43,168 +43,90 @@ or in the package mode (by pressing `]`):
 
 ## Usage
 
-Several vector symbolic architectures are implemented (see `?AbstractHV` for all subtypes),
-having different interfaces for hypervector creation:
+### Creating hypervectors
+
+Several vector symbolic architectures are implemented (see `?AbstractHV` for all subtypes).
+They all share the same constructor convention:
 
 ```julia
 using HyperdimensionalComputing
 
-julia> x = BinaryHV() # default length is 10,000
-10000-element BinaryHV:
- 1
- 0
- 0
- 0
- 0
- 1
- 1
- 0
- ⋮
- 1
- 0
- 1
- 0
- 1
- 0
- 0
- 0
-
-julia> y = BipolarHV(6) # different size
-6-element BipolarHV:
-  1
- -1
-  1
-  1
- -1
-  1
-
-julia> z = TernaryHV([1, 1, -1, 0, 0, 0, 1, 1, -1, 0]) # From a vector
-10-element TernaryHV:
-  1
-  1
- -1
-  0
-  0
-  0
-  1
-  1
- -1
-  0
+x = BinaryHV()                                    # fresh random hypervector, 10,000 dimensions
+y = BipolarHV(; D = 64)                           # dimensionality is set with the keyword D
+z = TernaryHV([1, 1, -1, 0, 0, 0, 1, 1, -1, 0])   # wrap an existing vector
 ```
 
-Hypervectors can be combined to represent more complex structures.  The basic operations are
-`bundle` (creating a vector that is similar to the provided vectors), `bind` (creating a vector
-that is dissimilar to the vectors) and `shift` (shifting the vector to create a new vector). For
-`aggregate` and `bind`, we overload `+` and `*` as binary operators, while `ρ` (`\rho`) is an
-alias for `shift`. For each VSA
+The positional argument is reserved for *the object you want to encode*: `HV(this)` returns
+the deterministic hypervector representing `this`, seeded by `hash(this)`. Any token — a
+symbol, string, character, number — gets its own reproducible, quasi-orthogonal hypervector:
 
 ```julia
-julia> x, y, z = GradedHV(10), GradedHV(10), GradedHV(10);
+julia> cat = BipolarHV(:cat)
+10000-element BipolarHV with 5078 positives and 4922 negatives:
+ -1
+ -1
+ -1
+  ⋮
+ -1
+  1
 
-julia> bundle([x,y,z])
-10-element GradedHV{Float64}:
- 0.24160752324192117
- 0.0004620105852614061
- 0.21122703146393468
- 0.8806160209097325
- 0.748086047467331
- 0.29234791431258145
- 0.2804922831134219
- 0.18556141274368268
- 0.08208462507331278
- 0.9015873952761569
+julia> cat == BipolarHV(:cat)  # the same object always yields the same hypervector
+true
 
-julia> x + y + z
-10-element GradedHV{Float64}:
- 0.24160752324192117
- 0.0004620105852614061
- 0.21122703146393468
- 0.8806160209097325
- 0.748086047467331
- 0.29234791431258145
- 0.2804922831134219
- 0.18556141274368268
- 0.08208462507331278
- 0.9015873952761569
+julia> similarity(cat, BipolarHV(:dog))  # different objects are quasi-orthogonal
+0.001
+```
+
+> [!IMPORTANT]
+> The positional argument is never a dimension: `BinaryHV(6)` is the 10,000-dimensional
+> hypervector *encoding the number 6*. Use `BinaryHV(; D = 6)` to set the dimensionality.
+
+### Operations
+
+Hypervectors can be combined to represent more complex structures. The basic operations are
+`bundle` (creating a vector that is similar to the provided vectors), `bind` (creating a vector
+that is dissimilar to the vectors) and `shift` (cyclically shifting the vector, used to encode
+position). For `bundle` and `bind`, we overload `+` and `*` as binary operators, while `ρ`
+(`\rho`) is an alias for `shift`. Each VSA uses its own implementation of these operations.
+
+```julia
+julia> x, y, z = GradedHV(; D = 5), GradedHV(; D = 5), GradedHV(; D = 5);
+
+julia> bundle([x, y, z])
+5-element GradedHV{Float64} with μ ± σ = 0.786 ± 0.435:
+ 0.9980386053693185
+ 0.9994897128289538
+ 0.9696790867890732
+ 0.008871444428233321
+ 0.9548707362741092
+
+julia> x + y + z == bundle([x, y, z])
+true
 
 julia> bind([x, y, z])
-10-element GradedHV{Float64}:
- 0.5061620120454368
- 0.26070792597812487
- 0.513025014409134
- 0.4717013369896599
- 0.49961155414024105
- 0.46309236900588013
- 0.5006006610486007
- 0.533210817253628
- 0.529186380757248
- 0.46622954535393824
+5-element GradedHV{Float64} with μ ± σ = 0.536 ± 0.232:
+ 0.5340650961987313
+ 0.3071283370775813
+ 0.5324987246729835
+ 0.9135871730556507
+ 0.3929268002269075
 
-julia> x * y * z
-10-element GradedHV{Float64}:
- 0.5061620120454368
- 0.26070792597812487
- 0.513025014409134
- 0.4717013369896599
- 0.49961155414024105
- 0.46309236900588013
- 0.5006006610486007
- 0.533210817253628
- 0.529186380757248
- 0.46622954535393824
+julia> x * y * z == bind([x, y, z])
+true
 
 julia> shift(x, 2)
-10-element GradedHV{Float64}:
- 0.6572388961520694
- 0.38592896770130286
- 0.5732316268033676
- 0.1280407117618328
- 0.13125571831454053
- 0.40139428175287556
- 0.5286213065298765
- 0.1038774285737532
- 0.43575817327464744
- 0.32479919832749704
+5-element GradedHV{Float64} with μ ± σ = 0.899 ± 0.157:
+ 0.9857814092925962
+ 0.9345994482275566
+ 0.9844262541167156
+ 0.9709891727120051
+ 0.6206103652316713
 
-julia> ρ(x, 2)
-10-element GradedHV{Float64}:
- 0.6572388961520694
- 0.38592896770130286
- 0.5732316268033676
- 0.1280407117618328
- 0.13125571831454053
- 0.40139428175287556
- 0.5286213065298765
- 0.1038774285737532
- 0.43575817327464744
- 0.32479919832749704
-
-julia> shift!(x, 2)
-10-element Vector{Float64}:
- 0.6572388961520694
- 0.38592896770130286
- 0.5732316268033676
- 0.1280407117618328
- 0.13125571831454053
- 0.40139428175287556
- 0.5286213065298765
- 0.1038774285737532
- 0.43575817327464744
- 0.32479919832749704
-
-julia> x
-10-element GradedHV{Float64}:
- 0.6572388961520694
- 0.38592896770130286
- 0.5732316268033676
- 0.1280407117618328
- 0.13125571831454053
- 0.40139428175287556
- 0.5286213065298765
- 0.1038774285737532
- 0.43575817327464744
- 0.32479919832749704
+julia> ρ(x, 2) == shift(x, 2)
+true
 ```
+
+In-place variants `shift!`, `ρ!`, `perturbate!` and `normalize!` are also available.
 
 Additionally, we provide common encoder strategies for different data structures:
 
@@ -218,24 +140,24 @@ Additionally, we provide common encoder strategies for different data structures
 - `graph`
 - `level`
 
-Finally, `similarity` function can be used to compute two hypervectors, by default using the
-best similarity metric for the hypervector type:
+Finally, the `similarity` function can be used to compare two hypervectors, by default using
+the best similarity metric for the hypervector type:
 
 ```
-julia> a = GradedBipolarHV(10);
+julia> a = GradedBipolarHV(:a);
 
-julia> b = GradedBipolarHV(10);
+julia> b = GradedBipolarHV(:b);
 
-julia> c = a + b;
+julia> c = a + b;  # bundling preserves similarity to the inputs
 
 julia> similarity(a, b)
-0.7857595020921353
+0.007006016597693629
 
 julia> similarity(a, c)
-0.9241024788902716
+0.6740992305784635
 
 julia> similarity(b, c)
-0.9295606930584789
+0.6824065675304283
 ```
 
 For more information, refer to the documentation.

--- a/TODO.md
+++ b/TODO.md
@@ -150,7 +150,11 @@ exactly 0.0 when both are built from one shared `level(...)` ladder.
 - [ ] Fix: build the ladder once in `convertlevel` (and/or make `level`
   deterministic given the base vector), then assert the roundtrip in tests.
 
-### 1.5c `perturbate` resamples from the TYPE-default distribution, not `hv.distr`
+### 1.5c `perturbate` resamples from the TYPE-default distribution, not `hv.distr` — FIXED (2026-07-14)
+Instance-level `eldist(hv) = hv.distr` methods added for RealHV/GradedHV/
+GradedBipolarHV (the type-level defaults stay for constructors); `level()` ladders
+built from custom-distr hypervectors are fixed by the same dispatch. Locked by a
+resampled-element statistics testset in `test/operations.jl`. Original notes:
 Found (by execution) during the §1.5 pattern sweep, deliberately not fixed in that
 PR. `eldist(hv::AbstractHV) = eldist(typeof(hv))` (`src/types.jl`) ignores the
 instance's `distr`, and the byte-vec `perturbate!` methods draw replacement
@@ -159,7 +163,7 @@ resamples with std ≈ 1.01 (should be ≈ 5); `GradedHV(distr = Beta(10, 2))` (
 0.833) resamples with mean ≈ 0.498. The result *carries the right `distr`
 metadata but wrong-distribution elements* — the same silent-numerics family as
 §1.5. Also affects `level()` ladders built from custom-distr hypervectors.
-- [ ] Fix: `eldist(hv::RealHV) = hv.distr` (and GradedHV/GradedBipolarHV);
+- [x] Fix: `eldist(hv::RealHV) = hv.distr` (and GradedHV/GradedBipolarHV);
   lock with a resampled-element statistics test like the ones above.
 
 ### 1.5b `unbind` / `/` for RealHV — RESOLVED by design decision (2026-07-14)

--- a/TODO.md
+++ b/TODO.md
@@ -154,10 +154,16 @@ by the new `unbind` testset (see §5).
   dispatches on `::TernaryHV` and now actually shows positives/zeros/negatives
   (visible in the regenerated TernaryHV doctest).
 
-### 1.8 Cross-type equality is wrong — FIXED (2026-07-14)
-`isequal` is now a same-type storage fast path; cross-type comparisons fall back
-to Base's elementwise semantics (`==` was already correct). The one-arg `hash`
-override was removed so hashing is element-based and consistent with equality.
+### 1.8 Cross-type equality is wrong — FIXED (2026-07-14, strengthened later same day)
+First pass: same-type storage fast path for `isequal`, one-arg `hash` removed
+(hashing element-based via the AbstractArray fallback). Strengthened after the
+polarity flip made the remaining hole real: Base's numeric fallback let an
+all-true BinaryHV equal an all-+1 BipolarHV (`true == 1`) even though their
+stored bits are opposite. `==`/`isequal` between DIFFERENT hypervector types are
+now strictly `false`; same-family cross-parameter (TernaryHV{Int8} vs {Int64})
+compares by value; comparisons against plain vectors stay elementwise, which is
+also why hashing must remain the unsalted element-based fallback
+(`isequal(hv, ::Vector)` can be true and must imply equal hashes).
 Locked by an equality/hashing testset (same bits, different type ⇒ not equal).
 Original notes:
 `Base.isequal(v::AbstractHV, u::AbstractHV) = v.v == u.v` (`src/operations.jl:225`)

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,28 @@ Ordered by priority: fix §1–§2 before anything else, §3–§5 before the ta
 
 ---
 
+## 0. Architecture (2026-07-14): the `encode` interface
+
+The package now has an explicit layer taxonomy: **primitives** (`operations.jl`)
+→ **combinators** (`encoding.jl`, hypervectors in/out — unchanged) → **encoders**
+(`encode.jl`, raw data in, hypervector out). Key points:
+
+- `encode(HV, x)` is the canonical, deterministic token path; `HV(x)` is sugar.
+- Constructors have one meaning each: `HV(n::Number)` **throws** (the old
+  one-time `@warn` and its testset are gone), invalid data arrays throw instead
+  of silently token-encoding (this killed the `BinaryHV([1, 0])` trapdoor), and
+  data constructors validate each type's element domain.
+- Sequence strategies dispatch on `AbstractEncoding`: `KMer(k)` **resolves issue
+  #53** (windows as atomic hashed tokens — genuinely different from `NGram(n)`,
+  which shift-binds symbol encodings via `ngrams`); also `Sequence()` and
+  `BagOfSymbols()`. Extension point: one struct + one `encode` method.
+- [ ] Follow-up PR: stateful encoders as an `AbstractEncoder{HV}` hierarchy with
+  `encode`/`decode` — `RandomProjection` (fixed projection matrix) and
+  `LevelEncoder` (fixed level set; subsumes the §1.4b ladder problem). `encode`
+  deliberately keeps its first argument free for encoder instances.
+
+---
+
 ## 1. Confirmed bugs (release blockers)
 
 ### 1.1 UnicodePlots extension fails to precompile — FIXED (2026-07-14)

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,390 @@
+# JuliaCon Readiness TODO — HyperdimensionalComputing.jl
+
+Audit date: 2026-07-13. All bugs below were **reproduced on the current `main`**
+(tests pass: 268/268, but coverage gaps hide every one of these).
+Ordered by priority: fix §1–§2 before anything else, §3–§5 before the talk,
+§6–§7 as time allows.
+
+---
+
+## 1. Confirmed bugs (release blockers)
+
+### 1.1 UnicodePlots extension fails to precompile — FIXED (2026-07-14)
+- [x] `show` now lives only in `src/representations.jl` and delegates to the
+  extension's `_show_rich` via `Base.get_extension` when UnicodePlots is loaded
+  (plain Base array display otherwise, and always under `:compact`). The plain
+  header comes from per-type `Base.summary` methods; Base handles elements and
+  `⋮` truncation. The extension defines no `Base.show` methods and precompiles
+  cleanly; `unicodeheatmap`/`unicodehistogram` are exported, user-callable stubs
+  implemented in the extension.
+
+### 1.2 Displaying a `BipolarHV` with the extension loaded throws — FIXED (2026-07-14)
+- [x] `getindex` restricted to `i::Integer` plus a non-scalar
+  `I::AbstractVector` method on all types (`ifelse.(hv.v[I], 1, -1)` for
+  `BipolarHV`). Decision, documented in the `AbstractHV` docstring: non-scalar
+  indexing returns a plain `Vector` of element values, never a new hypervector.
+  Covered by getindex tests in `test/representations.jl`.
+
+### 1.3 `perturbate` is broken for FHRR — FIXED (2026-07-14)
+FHRR-specific `perturbate!` methods resample phases (`exp(2πi·rand())`) at the
+selected positions, keeping unit modulus; `level(::FHRR, ...)` dispatch verified.
+Locked by FHRR perturbate tests in `test/operations.jl`. Original notes:
+`eldist(::Type{<:FHRR})` is not defined, so `perturbate(FHRR(), 10)` throws a
+`MethodError` (`src/operations.jl:290` calls `eldist(hv)`; `src/types.jl` defines
+`eldist` for every type except FHRR). Even with an `eldist`, the generic byte-vec
+path would need unit-modulus draws.
+- [x] Implement FHRR perturbation properly (resample phases, e.g.
+  `exp(2πi·rand())`, or add phase noise) and add a test.
+- [x] Consequence: `level(::FHRR, ...)` correctly has its own `^`-based method,
+  but generic `level()` on FHRR via the `AbstractHV` fallback would also break — verify dispatch.
+
+### 1.4 `decodelevel` / `convertlevel` instance path is broken — FIXED (2026-07-14)
+The vector `decodelevel` methods now accept (and ignore) `testbound`, so the
+generic instance-path forwarding no longer mis-dispatches. Locked by tests in
+`test/encoding.jl`. **See the new §1.4b found while verifying.** Original notes:
+`decodelevel(BipolarHV(), 0:0.1:1)` throws
+`MethodError: no method matching level(::Vector{BipolarHV}, ::Int64)`.
+Cause: `src/encoding.jl:595` forwards `; testbound` to
+`decodelevel(hvlevels::AbstractVector{<:AbstractHV}, numvalues)` (`:583`) which
+accepts **no kwargs**, so the call re-enters the generic method with the level
+vector as first argument. `convertlevel(hv, vals)` for non-FHRR types is broken
+the same way. (Same family as the already-fixed `convertlevel` kwargs bug.)
+- [x] Accept (and use or ignore) `testbound` in the vector method, or stop
+  forwarding it; add tests for the instance-based `encodelevel`/`decodelevel`/`convertlevel` paths.
+
+### 1.5 `bundle` silently drops custom distributions — FIXED (2026-07-14)
+`bundle` and `bind` now propagate the first operand's `distr` for
+RealHV/GradedHV/GradedBipolarHV; locked by a testset asserting `.distr === x.distr`
+and that `normalize!(x + y)` rescales to the original spread. Original notes:
+For `RealHV`/`GradedHV`/`GradedBipolarHV` with a non-default `distr`, bundling
+returns a result carrying the **default** distribution
+(`src/operations.jl:130–152` construct `RealHV(r)` etc. without passing `distr`).
+`normalize!(::RealHV)` rescales by `std(hv.distr)`, so this changes numerics, not
+just metadata. Same bug class as the fixed `GradedHV.similar` issue.
+- [x] Propagate `first(hdvs).distr` in the three `bundle` methods; check `bind`
+  (`operations.jl:176–178`) for the same issue; add tests.
+
+### 1.6 `shift!` returns the wrapped vector, not the hypervector — FIXED (2026-07-14)
+Generic `shift!` and the three clamp!-based `normalize!` methods now return the
+hypervector; locked by a testset asserting `op!(hv) === hv` for all types and all
+in-place ops. Original notes:
+Generic `shift!(hv, k) = circshift!(hv.v, k)` (`src/operations.jl:201`) returns a
+raw `Vector`, while the `BinaryHV`/`BipolarHV` methods (`:209`) return the HV.
+The README even shows `shift!(x, 2)` printing a `Vector{Float64}` as if normal.
+- [x] Make all in-place ops return the hypervector; same check for `ρ!`,
+  `normalize!` (mostly OK) and `perturbate!`.
+
+### 1.7 `δ` is a non-`const` global — FIXED (2026-07-14)
+`const δ = similarity`; locked by an `isconst` test. Original notes:
+`src/inference.jl:84`: `δ = similarity` — an exported, untyped, non-const
+binding (type-unstable at call sites, and `isconst(HDC, :δ) == false`).
+- [x] Change to `const δ = similarity`.
+
+### 1.2b BipolarHV bit↦value convention flipped — COMPLETED (2026-07-14)
+All follow-ups landed via a systematic audit of every `.v`-touching site (25 sites,
+each given an explicit verdict): sign-based `BipolarHV(v::AbstractVector{<:Real})`
+constructor that **throws on zero elements** (pointing to `TernaryHV`); summary
+labels corrected; docstring rewritten (XOR IS the ±1 product, `x * x` = all-`+1`
+identity, Bool vectors = raw stored bits); doctests + README regenerated;
+polarity-locking tests added (`all(x * x .== 1)`, construction/indexing
+round-trip, zero-throw, summary-count checks) since all prior property tests were
+polarity-blind. Verified correct without change: bundle majority vote (mapping-
+invariant), the bipolar `dot` formula (algebraically matches the new mapping),
+`isapprox` (element-based), hash/isequal (storage-based, self-consistent),
+shift/perturbate (bit-level, symmetric). Noted under issue #15: tie-break
+outcomes for identical inputs flipped sign with the mapping (still a fair coin).
+
+Original notes below for the record:
+Michiel changed the mapping to `Base.getindex(hv::BipolarHV, i::Integer) = hv.v[i] ? -1 : 1`
+(stored bit `true ↦ -1`, `false ↦ +1`). **This is deliberate**: with `v = (-1)^bit`,
+XOR on the stored bits is now *exactly* the elementwise `±1` product, so bind-as-XOR
+is the true MAP multiply (the old "negated product" wart is gone). `sum` was updated
+accordingly; `dot` is symmetric under the flip and needed no change. Verified:
+`x * y == x .* y` elementwise, `sum`/`dot` consistent with element values.
+
+Remaining inconsistencies found by verification (not yet fixed):
+- [x] `BipolarHV(v::AbstractVector{<:Integer}) = BipolarHV(v .> 0)` (`src/types.jl:213`)
+  now **negates the input**: `BipolarHV([-1, 0, 1])` gives values `[1, 1, -1]`.
+  Should be `v .< 0`; decide what `0` maps to (it flips from `-1` to `+1` semantics).
+  The test `BipolarHV([-1, 0, 1]) == BipolarHV([false, false, true])` in
+  `test/types.jl` currently locks in the inverted behaviour — update it with the fix.
+- [x] `Base.summary(io, hv::BipolarHV)` (`src/representations.jl:18`) still labels
+  `count(hv.v)` as "positives", but true bits are now `-1`: `[-1, -1, 1]` prints as
+  "2 positives and 1 negatives". Swap the labels (the display test only checks the
+  pattern, so it passes silently).
+- [x] BipolarHV docstring: delete the now-false "*negated* elementwise product" note
+  (it IS the product now — say so), fix "positive entries become `+1`" once the
+  integer constructor is fixed, and regenerate its doctest outputs
+  (`doctest(fix = true)`) — element signs flipped, so **the doctest CI job fails
+  until this is done**.
+
+### 1.4b Instance-path `convertlevel` builds encoder and decoder over DIFFERENT ladders
+Found (by execution) while fixing §1.4, deliberately NOT fixed in that PR.
+`convertlevel(hv::AbstractHV, numvals)` calls `encodelevel(hv, ...)` and
+`decodelevel(hv, ...)`, each of which builds its own `level(hv, m)` ladder — and
+`level` perturbation is unseeded, so the two ladders share only the base vector.
+Measured: `decode(encode(x))` errors up to 1.0 (mean 0.41) on the instance path vs
+exactly 0.0 when both are built from one shared `level(...)` ladder.
+- [ ] Fix: build the ladder once in `convertlevel` (and/or make `level`
+  deterministic given the base vector), then assert the roundtrip in tests.
+
+### 1.5c `perturbate` resamples from the TYPE-default distribution, not `hv.distr`
+Found (by execution) during the §1.5 pattern sweep, deliberately not fixed in that
+PR. `eldist(hv::AbstractHV) = eldist(typeof(hv))` (`src/types.jl`) ignores the
+instance's `distr`, and the byte-vec `perturbate!` methods draw replacement
+elements from it. Measured: `perturbate(RealHV(distr = Normal(0, 5)), 5000)`
+resamples with std ≈ 1.01 (should be ≈ 5); `GradedHV(distr = Beta(10, 2))` (mean
+0.833) resamples with mean ≈ 0.498. The result *carries the right `distr`
+metadata but wrong-distribution elements* — the same silent-numerics family as
+§1.5. Also affects `level()` ladders built from custom-distr hypervectors.
+- [ ] Fix: `eldist(hv::RealHV) = hv.distr` (and GradedHV/GradedBipolarHV);
+  lock with a resampled-element statistics test like the ones above.
+
+### 1.5b `unbind` / `/` for RealHV — RESOLVED by design decision (2026-07-14)
+Was an accidental `MethodError` (the old `Union{RealHV, FHRR}` division method
+constructed via the concrete type). **Decision (Michiel): real-valued MAP binding
+is not exactly invertible, so `unbind(::RealHV, ::RealHV)` now throws an explicit
+`ArgumentError`** pointing users to `similarity` against candidate hypervectors,
+or to `FHRR`/`BipolarHV` for exact unbinding. FHRR kept its exact elementwise
+division. `unbind`, `bind` and `RealHV` docstrings updated accordingly; covered
+by the new `unbind` testset (see §5).
+
+### 1.7b TernaryHV pretty-printing branch is dead code — FIXED (2026-07-14)
+- [x] Resolved by the `Base.summary` refactor (§1.1): the ternary header
+  dispatches on `::TernaryHV` and now actually shows positives/zeros/negatives
+  (visible in the regenerated TernaryHV doctest).
+
+### 1.8 Cross-type equality is wrong — FIXED (2026-07-14)
+`isequal` is now a same-type storage fast path; cross-type comparisons fall back
+to Base's elementwise semantics (`==` was already correct). The one-arg `hash`
+override was removed so hashing is element-based and consistent with equality.
+Locked by an equality/hashing testset (same bits, different type ⇒ not equal).
+Original notes:
+`Base.isequal(v::AbstractHV, u::AbstractHV) = v.v == u.v` (`src/operations.jl:225`)
+makes `isequal(BinaryHV([1,0]), BipolarHV([1,0])) == true` — a binary vector
+"equals" a bipolar one because the underlying BitVectors match. Also
+`Base.hash(hv) = hash(hv.v)` (`src/types.jl:28`) is a one-arg overload that is
+inconsistent with the two-arg `hash(hv, h)` fallback for `BipolarHV`
+(elements hash as ±1, storage hashes as bits).
+- [x] Restrict `isequal`/`==` to same HV type; define `hash(hv, h::UInt)`
+  consistently with equality instead of the one-arg form.
+
+---
+
+## 2. API design decisions (breaking — settle *before* registering)
+
+### 2.1 The positional-constructor trap (biggest UX footgun)
+
+> **Note (2026-07-13, Michiel):** this is a *deliberate*, already-decided breaking
+> change — the intended interface is `HV(this::Any; D::Int = 10_000, seed/rng)`,
+> where the positional argument is always the thing to encode (seeded by its hash),
+> and some types add special constructors depending on the datatype. The design was
+> documented once, but the commits were lost. So the task below is **not** to
+> re-decide the API but to (re)document the convention prominently (docstrings on
+> every constructor + a docs section) and bring README/docstring examples/tests in
+> line with it.
+
+`HV(x)` for any non-vector `x` means "deterministic vector seeded by `hash(x)`",
+**including integers**:
+- `BipolarHV(6)` → a 10,000-dim vector seeded by `hash(6)` — but the README
+  claims it creates a 6-element vector and shows fabricated output.
+- `[BinaryHV(10) for _ in 1:10]` → ten **identical** vectors. Every docstring
+  example in `src/encoding.jl` uses this idiom and shows made-up 10-element
+  outputs that the code cannot produce (GitHub issue #36).
+- Even the test suite fell into it: `test/operations.jl:25,45` bundle/bind five
+  identical `HV(N)` vectors, weakening the tests.
+- [x] Re-document the convention: canonical statement + warning admonition on the
+  `AbstractHV` docstring; constructor docstrings on all 7 types (2026-07-14).
+- [x] Fix README (rewritten Usage section with real outputs), all `encoding.jl`
+  docstring examples (regenerated with `HV.(tokens; D = 10)` and real outputs,
+  including a filled-in `graph` example), and the tests (`HV(i; D = N)` in
+  `test/operations.jl`; new "constructor convention" testset in `test/types.jl`
+  locking `length(HV(42)) == 10_000`, determinism, and `D` kwarg for all types).
+- [x] Runtime guard added (2026-07-14): all token constructors call
+  `warn_integer_token`, which emits a one-time-per-session `@warn` (via
+  `maxlog = 1`) when an `Integer` is passed positionally, pointing the user to
+  `D = n`. `Bool` tokens are exempt; behavior is unchanged (still encodes the
+  integer). Covered by `@test_logs` tests in `test/types.jl`.
+
+### 2.2 Extending `Base.bind`
+`bind` already exists in `Base` (for Channels/Sockets); the package extends and
+re-exports it (`src/operations.jl:172`). Legal (own types), but surprising and
+flagged by tooling.
+- [ ] Decide: own `bind` function (breaks `Base.bind` extension) vs keep. Run
+  Aqua.jl piracy/ambiguity checks either way (see §5).
+
+### 2.3 `similar` returns a *random* vector
+`Base.similar(hv)` (`src/types.jl:29`) violates the Base contract (uninitialized
+container) by returning a fresh random hypervector, and does so with the global RNG.
+- [ ] Rename the internal helper (e.g. `randlike(hv)`) and stop overloading `Base.similar`,
+  or document the deviation prominently.
+
+### 2.4 `normalize` name clash
+`normalize`/`normalize!` are package-own functions (only `norm`/`dot` are imported
+from LinearAlgebra), so `using LinearAlgebra, HyperdimensionalComputing` gives
+users an export conflict.
+- [ ] Extend `LinearAlgebra.normalize(!)` instead of defining new functions.
+
+### 2.5 Smaller decisions to document (or fix)
+- [x] ~~`TernaryHV()` random constructor never generates 0 — document~~ (documented in the TernaryHV docstring, 2026-07-14).
+- [x] ~~No `setindex!`: document immutability on `AbstractHV`~~ (documented in the `# Indexing` section, 2026-07-14).
+- [ ] FHRR `unbind` uses elementwise `/`; conjugate multiplication is the idiomatic,
+  numerically safer choice for unit-modulus vectors.
+- [ ] FHRR `bundle` does `r ./= abs.(r)` — NaN if elements cancel exactly; guard or document.
+- [x] ~~Default RNG is `MersenneTwister`~~ — RNG handling modernized (2026-07-14):
+  `Xoshiro` throughout, `Random.GLOBAL_RNG` → `Random.default_rng()`, the `rng`
+  keyword now takes an `AbstractRNG` *instance* (`HV(; D, seed, rng = Random.default_rng())`,
+  `seed` builds a fresh `Xoshiro(seed)`), and the deterministic constructor is
+  `HV(this; D)` — no `rng` keyword; always `Xoshiro(hash(this))`. Breaking in
+  output: every seeded/token vector changed; README + example outputs regenerated.
+
+---
+
+## 3. README (the first thing JuliaCon attendees will open)
+
+- [x] ~~All usage examples are stale~~ — Usage section rewritten (2026-07-14):
+  constructor convention explained with real outputs, `D` kwarg shown, operations
+  and similarity blocks regenerated; the misleading `shift!` output block dropped.
+- [ ] Broken CI badge: points to `MichielStock/...` and a workflow named `CI`;
+  the repo is `Kermit-UGent/...` and the workflow is `Test suite`.
+- [x] ~~Truncated sentence "…For each VSA"~~ (completed 2026-07-14).
+- [ ] Claims "Basic functionality for fitting a k-NN like classifier is also
+  supported" — no `train`/`predict` exists (see §7.1). Remove the claim or ship the feature.
+- [ ] Update installation instructions once registered (`Pkg.add("HyperdimensionalComputing")`).
+- [ ] Unify org capitalization (`KERMIT-UGent` vs `Kermit-UGent`) in links.
+- [ ] Add a docs badge that actually resolves + a Codecov badge once §5 lands.
+
+---
+
+## 4. Documentation
+
+### Structural
+- [ ] `docs/src/index.md` `@contents` references non-existent `examples.md`
+  (actual pages live in `examples/`).
+- [ ] `docs/src/developers.md` is built but missing from the `pages` nav in `docs/make.jl:35–42`.
+- [ ] `makedocs(repo = "...string...")` triggers a navbar warning — pass
+  `Remotes.GitHub("Kermit-UGent", "HyperdimensionalComputing.jl")`.
+- [ ] Committed generated files `docs/src/examples/*.md` are stale Literate output
+  from the **old `BipolarHDV` API** (incl. a `Handcalcs` reference). They're
+  regenerated at build time — delete and gitignore them.
+- [ ] `docs/Project.toml`: `Handcalcs` is no longer used by any tutorial — remove.
+  `CairoMakie`/`Colors` are only needed by `logo.jl` — consider a separate env so
+  docs CI doesn't compile Makie. Add compat bounds (esp. Documenter).
+- [ ] Restructure docs per issue #32: pages for Types/VSAs, Operations,
+  Comparison & inference, then examples.
+
+### Content
+- [x] ~~Missing docstrings on type names~~: all 7 types + `AbstractHV` rewritten to a
+  shared template with seeded `jldoctest` examples (2026-07-14); `bundle` and `bind`
+  got docstrings too. Still missing: `shift`/`ρ`, `perturbate(!)`, `^` for FHRR.
+  Note: the type docstrings contain literal `<<<DECIDE>>>` markers for the documented
+  RNG default and the binary/bipolar element-set notation — resolve before release.
+- [x] ~~`# Example` blocks in `src/encoding.jl` use the `BinaryHV(10)` trap with
+  fabricated outputs~~ — rewritten with token-based construction and real outputs
+  (2026-07-14). Type docstrings now use `jldoctest` with outputs generated by
+  `doctest(fix = true)` and enforced in CI (doctests job in `test.yml` + the docs
+  build). Follow-up: migrate the `encoding.jl` examples to `jldoctest` too.
+- [x] ~~`graph` docstring: `# Example` section is empty~~ (filled in 2026-07-14).
+- [ ] Second `isapprox` docstring (`src/operations.jl:248–256`): header line shows
+  the wrong kwargs (`atol`/`ptol` instead of `ptol`/`N_bootstrap`) and says
+  `N_bootstrap=200` while the code default is `500`.
+- [ ] `similarity(u, v; method)` docstring says "When no method is given, a default
+  is used" but `method` is a mandatory kwarg for plain vectors (`src/inference.jl:38`).
+  Also `:hamming` returns a match *count*, not a similarity in [0,1] — document or normalize.
+- [ ] Typo `src/inference.jl:71`: "and `u`` " (stray backtick).
+- [ ] `level` docstring: document the perturbation-based correlation mechanism and the FHRR `^`-based variant.
+- [ ] Issue #36: the intro tutorial's ngrams example yields the wrong result — re-derive it.
+- [ ] Developer docs: how to add a new HV type (required methods: constructor,
+  `eldist`, `empty_vector`, `bundle`, `bind`, `similarity`, traits…).
+
+---
+
+## 5. Tests & QA
+
+Coverage gaps (each hid a §1 bug):
+- [x] ~~`unbind` / `/`: zero tests package-wide~~ — `unbind` testset added to
+  `test/operations.jl` (2026-07-14): exact roundtrips for Binary/Bipolar/Ternary,
+  approximate fuzzy recovery for the graded types, exact FHRR division, and the
+  explicit `ArgumentError` for RealHV.
+- [ ] `perturbate` on FHRR (currently broken, §1.3).
+- [ ] Instance-path `encodelevel`/`decodelevel`/`convertlevel` (currently broken, §1.4).
+- [ ] `bundle`/`bind` preserving custom `distr` (§1.5).
+- [ ] `similarity(...; method = :jaccard / :hamming)` — only `:cosine` is tested.
+- [ ] `isapprox` bootstrap path — the whole similarity testset is skipped for
+  `TernaryHV`/`GradedHV`/`GradedBipolarHV`/`RealHV` (`test/operations.jl:71`).
+- [x] ~~`show` methods and the UnicodePlots extension untested~~ — added
+  `test/representations.jl` (plain display for all 7 types + getindex) and
+  `test/ext_display.jl` (rich display, run in a separate Julia process since
+  extension loading is irreversible) (2026-07-14).
+- [ ] Semantic property tests, not just type checks: bundle preserves similarity
+  to inputs; bind produces dissimilar output and is invertible via unbind;
+  shift preserves distance. Currently most tests only assert `isa`.
+
+Test hygiene:
+- [x] ~~`test/operations.jl`: `HV(N)` creates identical seeded vectors~~ (fixed to `HV(i; D = N)`, 2026-07-14).
+- [ ] Cross-file leakage: `n`, `s`, `hash_s` consts from `test/types.jl` are used
+  by `test/operations.jl` (`:90`) — scope per file or move to `runtests.jl`.
+- [ ] Declare `Distributions` and `Random` in `[extras]`/test target (currently
+  only `Test`); works today via the sandbox but is fragile and blocks test/Project.toml migration.
+- [ ] Add **Aqua.jl** (ambiguities, piracy — will flag `Base.bind`, unbound args,
+  stale exports, compat) and run **doctests** in CI.
+
+---
+
+## 6. CI / infrastructure / registration
+
+- [ ] `test.yml`: `setup-julia@v1` → `v2`; test a matrix — `min` (1.11), `1`,
+  `pre` — and at least ubuntu + one of macOS/Windows.
+- [ ] Add coverage (`julia-processcoverage` + Codecov) — closes the workflow TODO.
+- [ ] Add `CompatHelper.yml` and `TagBot.yml` (required plumbing for a registered package).
+- [ ] **Register in the General registry** (issue #9) — the JuliaCon audience must be
+  able to `] add HyperdimensionalComputing`. Compat bounds and license are already
+  in place; do this *after* the breaking decisions in §2.
+- [ ] `docs.yml` warning: deploy config fine, but fix the `repo` remote (§4).
+- [x] ~~Drop the `StatsBase` strong dependency~~ — removed from `[deps]` and
+  `[compat]` (2026-07-14); the extension no longer needs it (`mean`/`std` in
+  summaries come via the existing Distributions re-export).
+
+---
+
+## 7. Features & polish (nice-to-have for the talk)
+
+- [ ] **Classification workflow** (`train`/`predict`, prototype = bundle of class
+  examples + retraining on misclassified) — HDC's headline use case, promised by
+  the README, and the natural JuliaCon demo (language identification / MNIST, issue #32).
+- [ ] Dead code in `src/operations.jl`: `aggfun`, `bindfun`, `neutralbind`,
+  `noisy_and`, `elementreduce!`, `offsetcombine(!)` and `Base.zeros(::GradedHV)`
+  (`src/types.jl:271`) are never called — delete or wire in.
+- [ ] `crossproduct` TODO: should bundle without normalizing (`src/encoding.jl:373`).
+- [ ] `SparseHV` (long-standing TODO in `src/types.jl`) — fine to skip for JuliaCon.
+- [ ] Triage open issues for the roadmap slide: #53 k-mer encoder, #50 VSA aliases,
+  #42 Makie recipe, #25 concatenation, #16 level-encoding strategies,
+  #15 tie-breaking strategies, #14 naming conventions, #10 stateful encoding.
+
+---
+
+## Suggested order of attack (updated 2026-07-14, end of session)
+
+Done so far: constructor convention documented + runtime guard; RNG modernized
+(Xoshiro, instance `rng`, `HV(this; D)`); display/extension architecture fixed and
+tested; all 8 type docstrings templated with CI-enforced doctests; `unbind`
+tested everywhere and made an explicit error for RealHV; README rewritten;
+StatsBase dropped. Test suite grew 268 → ~450 assertions plus doctests.
+
+1. **§1.2b BipolarHV mapping-flip follow-ups — do this first, the doctest CI job
+   is red until it lands**: fix the integer-vector constructor (`v .> 0` →
+   `v .< 0`, decide zero semantics), swap the summary labels, refresh the
+   BipolarHV docstring text, re-run `doctest(fix = true)`, update the locked-in
+   test in `test/types.jl`.
+2. Remaining §1 bugs, one small PR each with a locking test: `perturbate` on FHRR
+   (§1.3), instance-path `decodelevel`/`convertlevel` (§1.4), `bundle` dropping
+   `distr` (§1.5), `shift!` return value (§1.6), `const δ` (§1.7),
+   cross-type `isequal`/`hash` (§1.8).
+3. §2 API decisions before registration: `Base.bind` extension (run Aqua.jl and
+   decide), `similar` returning a random vector, `normalize` name clash.
+4. Registration track (§6): CI matrix (min/1/pre, macOS/Windows), coverage +
+   Codecov, CompatHelper + TagBot, Aqua in tests → register in General (issue #9).
+5. Docs polish (§3/§4): README badge + k-NN claim, docs restructure per issue #32,
+   fix the intro tutorial ngrams example (issue #36), remaining function docstrings
+   (`shift`/`ρ`, `perturbate`, `level`, `^` for FHRR).
+6. §7.1 classification workflow (`train`/`predict`) — the JuliaCon demo.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,8 +1,10 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 Handcalcs = "e8a07092-c156-4455-ab8e-ed8bc81edefb"
 HyperdimensionalComputing = "ebb7690e-f605-4e7a-86a0-727dbed6b293"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/docs/logo.jl
+++ b/docs/logo.jl
@@ -64,7 +64,7 @@ function make_logo(; seed = 42, spacing = 1.0, R = 6.5, ρ = 9.0)
     for (color, c) in lobes
         pts = disc_dots(c[1], c[2], R; spacing = spacing)
         sz = dot_sizes(rng, length(pts); spacing = spacing)
-        scatter!(ax, pts; markersize = sz, markerspace = :data, color = color, strokecolor=:transparent)
+        scatter!(ax, pts; markersize = sz, markerspace = :data, color = color, strokecolor = :transparent)
     end
 
     limits!(ax, -ρ - R - 1, ρ + R + 1, -ρ * sind(30) - R - 1, ρ + R + 1)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,10 +10,13 @@ SOURCE_FILES = Glob.glob("*.jl", TUTORIALS)
 foreach(fn -> Literate.markdown(fn, TUTORIALS), SOURCE_FILES)
 
 # Setup Documenter.jl
+# The doctest setup mirrors what the doctest CI step uses: Xoshiro for seeded,
+# reproducible RNG in examples and Distributions for the `distr` keyword examples.
 DocMeta.setdocmeta!(
     HyperdimensionalComputing,
     :DocTestSetup,
-    :(using HyperdimensionalComputing); recursive = true
+    :(using HyperdimensionalComputing, Distributions; using Random: Xoshiro);
+    recursive = true
 )
 
 # Get repository information dynamically for fork support

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -57,4 +57,3 @@ deploydocs(;
         end
     end,
 )
-

--- a/docs/src/examples/introduction-to-hdc.jl
+++ b/docs/src/examples/introduction-to-hdc.jl
@@ -124,7 +124,7 @@ h₁ * h₂ * h₃
 #
 # $$m = \rho(h₁)$$
 
-h₄ = TernaryHV(collect(0:9))
+h₄ = RealHV(collect(0.0:9.0))
 h₄.v
 
 #

--- a/docs/src/examples/introduction-to-hdc.md
+++ b/docs/src/examples/introduction-to-hdc.md
@@ -149,7 +149,7 @@ positions.
 $$m = \rho(h₁)$$
 
 ````@example introduction-to-hdc
-h₄ = TernaryHV(collect(0:9))
+h₄ = RealHV(collect(0.0:9.0))
 h₄.v
 ````
 

--- a/docs/src/examples/introduction-to-hdc.md
+++ b/docs/src/examples/introduction-to-hdc.md
@@ -2,10 +2,6 @@
 EditURL = "introduction-to-hdc.jl"
 ```
 
-````@example introduction-to-hdc
-using Handcalcs #hide
-````
-
 # Introduction
 
 Hyperdimensional Computing (HDC) is a brain-inspired computational paradigm that represents
@@ -20,8 +16,6 @@ Let's start by loading the package in question, as follows:
 
 ````@example introduction-to-hdc
 using HyperdimensionalComputing
-
-ρ(hv::AbstractHDV, n::Int=1) = Π(hv,n) #hide
 ````
 
 # Creating hypervectors
@@ -29,7 +23,7 @@ using HyperdimensionalComputing
 First, we will create a random bipolar hypervector. This is done as follows:
 
 ````@example introduction-to-hdc
-BipolarHDV()
+BipolarHV()
 ````
 
 As you may see, by default the hypervector created has 10.000 dimensions. This is the default
@@ -37,32 +31,40 @@ value in `HyperdimensionalComputing.jl`, but one can can create a hypervector of
 dimensionality by providing the size of this as an argument:
 
 ````@example introduction-to-hdc
-BipolarHDV(8)
+BipolarHV(; D = 8)
 ````
 
-Alternatively, one can create a hypervector directly from a `AbstractVector`:
+Alternatively, one can create a hypervector directly from a `Vector{T}` where `{T}` is an
+appropiate data type, e.g. integers for BipolarHV:
 
 ````@example introduction-to-hdc
-BipolarHDV(rand([-1,1], 8))
+BipolarHV(rand((-1, 1), 8))
+````
+
+or you can directly pass any Julia structure to use it as a seed for the hypervector
+generation:
+
+````@example introduction-to-hdc
+BipolarHV(:foo)
 ````
 
 Let's create 3 bipolar hypervector to use for the tutorial:
 
 ````@example introduction-to-hdc
-h₁ = BipolarHDV(8)
-h₂ = BipolarHDV(8)
-h₃ = BipolarHDV(8);
+h₁ = BipolarHV(; D = 8)
+h₂ = BipolarHV(; D = 8)
+h₃ = BipolarHV(; D = 8);
 nothing #hide
 ````
 
-The package has different hypervector types, such as `BipolarHDV`, `TernaryHDV`, `RealHDV`,
-`GradedBipolarHDV`, and `GradedHDV`. All of this hypervectors have a common abstract type
-`AbstractHDV` which can be used to build additional functions or encoding strategies (more on
+The package has different hypervector types, such as `BipolarHV`, `TernaryHV`, `RealHV`,
+`GradedBipolarHV`, and `GradedHV`. All of this hypervectors have a common abstract type
+`AbstractHV` which can be used to build additional functions or encoding strategies (more on
 both later).
 
 !!! info "On (abstract) types"
     All hypervectors implemented on `HyperdimensionalComputing.jl` can be found by checking the
-    docstrings for the `AbstractHDV` (by typing `?AbstractHDV` on the Julia REPL).
+    docstrings for the `AbstractHV` (by typing `?AbstractHV` on the Julia REPL).
 
     For more information on a specific hypervector type, the docstrings contain information on
     the implementation, operations, similarity measurement and other technical
@@ -76,7 +78,7 @@ the representation more complex structures:
 ## Bundling
 
 Bundling (also known as superposition) combines multiple hypervectors to create a new hypervector
-that is similar to it's constituyents.
+that is similar to it's constituents.
 
 $$u = [h_1 + h_2 + h_3]$$
 
@@ -93,16 +95,16 @@ $$\text{sign}(i) = \begin{cases}
 In HyperdimensionalComputing.jl, you can bundle hypervectors as follows:
 
 ````@example introduction-to-hdc
-aggregate([h₁, h₂, h₃])
+bundle([h₁, h₂, h₃])
 ````
 
-alternatively, you can use the `+` operator (which if overloaded for all `AbstractHDV`):
+alternatively, you can use the `+` operator (which if overloaded for all `AbstractHV`):
 
 ````@example introduction-to-hdc
 h₁ + h₂ + h₃
 ````
 
-This operation generates a hypervector that is similar to all it's contituyent hypervectors,
+This operation generates a hypervector that is similar to all it's constituent hypervectors,
 such that
 
 $$h₁ \sim u, h₂ \sim u, h₃ \sim u$$
@@ -113,7 +115,7 @@ expected by chance.
 ## Binding
 
 Binding combines multiple hypervectors to create a new hypervector that is dissimilar to it's
-constituyents, such that:
+constituents, such that:
 
 $$v = [h₁ \times h₂ \times h₃]$$
 
@@ -125,13 +127,13 @@ In HyperdimensionalComputing.jl, you can bind hypervectors as follows:
 bind([h₁, h₂, h₃])
 ````
 
-alternatively, you can use the `*` operator (which if overloaded for all `AbstractHDV`):
+alternatively, you can use the `*` operator (which if overloaded for all `AbstractHV`):
 
 ````@example introduction-to-hdc
 h₁ * h₂ * h₃
 ````
 
-This operation generates a hypervector that is similar to all it's contituyent hypervectors,
+This operation generates a hypervector that is similar to all it's constituent hypervectors,
 such that
 
 $$h₁ \nsim v, h₂ \nsim v, h₃ \nsim v$$
@@ -147,15 +149,12 @@ positions.
 $$m = \rho(h₁)$$
 
 ````@example introduction-to-hdc
-@handcalcs h₁ # hide
+h₄ = TernaryHV(collect(0:9))
+h₄.v
 ````
 
 ````@example introduction-to-hdc
-@handcalcs ρ(h₁) # hide
-````
-
-````@example introduction-to-hdc
-@handcalcs h₁ != ρ(h₁) # hide
+ρ(h₄).v
 ````
 
 The new hypervector will be, in principle, dissimilar to it's original version, such that:
@@ -198,6 +197,17 @@ or a hypervector and a vector of hypervectors:
 similarity.(Ref(h₁), [h₁, h₂, h₃])
 ````
 
+`δ` is a synonim of `similarity`, and can also be used to create a function for similarity
+comparison, e.g.
+
+````@example introduction-to-hdc
+f = δ(h₁)
+````
+
+````@example introduction-to-hdc
+f.([h₁, h₂, h₃])
+````
+
 ## Encoding things as hypervectors
 
 The true power of HDC emerges when we combine the fundamental operations to encode complex data
@@ -212,75 +222,91 @@ explore some fundamental encoding strategies that demonstrate this flexibility.
 Animal hypervectors:
 
 ````@example introduction-to-hdc
-dog_hv = BipolarHDV()
-cat_hv = BipolarHDV()
-cow_hv = BipolarHDV()
-animals = [dog_hv, cat_hv, cow_hv]
+H_dog = TernaryHV(:dog)
+H_cat = TernaryHV(:cat)
+H_cow = TernaryHV(:cow)
+H_animals = [H_dog, H_cat, H_cow]
 ````
 
 Sound hypervectors:
 
 ````@example introduction-to-hdc
-bark_hv = BipolarHDV()
-meow_hv = BipolarHDV()
-moo_hv  = BipolarHDV()
-sounds = [bark_hv, meow_hv, moo_hv]
+H_bark = TernaryHV(:bark)
+H_meow = TernaryHV(:meow)
+H_moo = TernaryHV(:moo)
+H_sounds = [H_bark, H_meow, H_moo]
 ````
 
 Associative memory:
 
 ````@example introduction-to-hdc
-memory = (dog_hv * bark_hv) + (cat_hv * meow_hv) + (cow_hv * moo_hv);
+memory = (H_dog * H_bark) + (H_cat * H_meow) + (H_cow * H_moo);
 nothing #hide
+````
+
+!!! note
+
+````@example introduction-to-hdc
+#	  Alternatively you can use the `hashtable` encoder to achieve the same:
+
+memory == hashtable(H_animals, H_sounds)
 ````
 
 Querying memory to search for dog's sound:
 
 ````@example introduction-to-hdc
-findmax(hv -> similarity(memory * dog_hv, hv), sounds)
+nearest_neighbor(H_dog * memory, H_sounds)
 ````
 
-Querying memory to search which animals goes "moo":
+Querying memory to search which animals go "moo":
 
 ````@example introduction-to-hdc
-findmax(hv -> similarity(memory * moo_hv, hv), animals)
+nearest_neighbor(H_moo * memory, H_animals)
 ````
 
 This is a very simple example, but you could think of having a more complex thing going on or
-having more animal that, for example, share sounds.
+having more animals that, for example, share sounds.
 
 ### Sequences
 
 **N-grams** represent sequences by encoding the order of elements. This is particularly useful for text processing where word order matters.
 
-Generate hypervectors for all characters in the alphabet
+Encode the phrases using the builtin `ngrams` encoder, with uses a sliding window of 3
+characters.
 
-````@example introduction-to-hdc
-char2hv = Dict(c => BipolarHDV() for c in 'a':'z')
-char2hv[' '] = BipolarHDV()
-````
-
-Encode the phrases using 3-grams
+Let's encode some phrases and then search for a specific word in them. First, the sentences
+list:
 
 ````@example introduction-to-hdc
 phrases = [
-	"the quick brown fox jumps over the lazy dog",
-	"the slick grown box bumps under the hazy fog",
-	"the thick known cox dumps inter the crazy cog",
-	"the brick shown pox lumps enter the glazy jog",
-	"the stick blown sox pumps winter the blazy log"
-]
-
-ngrams(p, d) = aggregate([d[p[i]] + Π(d[p[i+1]], 1) + Π(d[p[i+2]], 2) for i in 1:length(p)-2])
-
-phrases_hvs = [ngrams(p, char2hv) for p in phrases]
+    "the quick brown fox jumps over the lazy dog",
+    "the slick grown box bumps under the hazy fog",
+    "the thick known cox dumps inter the crazy cog",
+    "the brick shown pox lumps enter the glazy jog",
+    "the stick blown sox pumps winter the blazy log",
+];
+nothing #hide
 ````
 
-Search for "crazy" in phrases
+Now, lets encode sentences using the characters as seed for our basis hypervectors and use n-gram
+encoding to represent the sentences as hypervectors:
 
 ````@example introduction-to-hdc
-query = ngrams("crazy", char2hv)
-findmax(h -> similarity(query, h), phrases_hvs)
+encode(p::String) = map(c -> BinaryHV(c), collect(p)) |> ngrams
+````
+
+````@example introduction-to-hdc
+H_phrases = map(encode, phrases)
+````
+
+Now that we have the sentence hypervectors, let's search for "crazy" in phrases:
+
+````@example introduction-to-hdc
+query = map(c -> BinaryHV(c), collect("crazy")) |> ngrams
+````
+
+````@example introduction-to-hdc
+nearest_neighbor(query, H_phrases)
 ````
 
 Great! We correctly found that "crazy" is in phrase 3.

--- a/docs/src/examples/whats-the-dollar-of-mexico.md
+++ b/docs/src/examples/whats-the-dollar-of-mexico.md
@@ -4,88 +4,152 @@ EditURL = "whats-the-dollar-of-mexico.jl"
 
 # Replicating "What’s the Dollar of Mexico?" in `HyperdimensionalComputing.jl`
 
+Kanerva showcases in this publication how we can create prototype concepts and mappings between
+them using Hyperdimensional Computing (HDC), a computing paradigm based on very big random vectors
+populated with binary values.
+
+This very big random vectors, which we calls "words" or "codes", represent concepts, but when
+analyzing this as mathematical constructs they are nothing else than random signals. When
+combined using bundling and binding operations, one can construct concepts and reason based on
+the similarity of this words, always assuming that this retrieval is approximated.
+
+Since the properties of the operations that enable composability of this "codes" are
+mathematically grounded, the characteristics of the operations permeate into this modelling
+mindset and enable for the creation of (i) prototype representations and (ii) mapping function,
+both based on the same underlying mathematical structure. Thanks to this, we can either model
+mapping one concept into another space or directly map a mapping function from one space into
+another, basically mimicking how the brain works:
+
+> The literal image created by the words is intended to be transferred to and interpreted in a
+  new context, exemplifying the mind's reliance on prototypes: the literal meaning provides the
+  prototype. When the mind expands its scope in this way it creates an incredibly rich web of
+  associations and meaning...
+
+To showcase this, we will reimplement the example proposed by Kanerva on this paper.
+
 ````@example whats-the-dollar-of-mexico
 using HyperdimensionalComputing
-using LinearAlgebra #hide
-
-HyperdimensionalComputing.similarity(u::T,v::T) where T<:BipolarHDV = dot(u, v) / (norm(u) * norm(v)) #hide
-HyperdimensionalComputing.isapprox(u::T, v::T) where T<:BipolarHDV = similarity(u, v) > 3/sqrt(length(v)) #hide
-HyperdimensionalComputing.hash(u::AbstractHDV) = hash(u.v, hash(typeof(v)))
-HyperdimensionalComputing.isequal(u::T, v::T) where T<:AbstractHDV = hash(u) == hash(v)
 ````
 
-Concept hypervectors
+In HDC, concepts are represented as high-dimensional random vectors (hypervectors).
+Here, we create hypervectors for the abstract concepts of COUNTRY, CAPITAL, and MONEY.
 
 ````@example whats-the-dollar-of-mexico
-COUNTRY = BipolarHDV()
-CAPITAL = BipolarHDV()
-MONEY = BipolarHDV()
+COUNTRY = BipolarHV(:country)
+CAPITAL = BipolarHV(:capital)
+MONEY = BipolarHV(:money)
+
+COUNTRY, CAPITAL, MONEY
 ````
 
-Holistic representation of countries
+Next, we create hypervectors for specific instances: countries, their capitals, and currencies.
 
 ````@example whats-the-dollar-of-mexico
-USA = BipolarHDV()
-MEX = BipolarHDV()
+USA = BipolarHV(:usa)
+MEX = BipolarHV(:mexico)
 
-WDC = BipolarHDV()
-MXC = BipolarHDV()
+WDC = BipolarHV(:wdc)      # Washington DC
+MXC = BipolarHV(:mxc)      # Mexico City
 
-DOL = BipolarHDV()
-PES = BipolarHDV()
+DOL = BipolarHV(:dollar)
+PES = BipolarHV(:peso)
 
+USA, MEX, WDC, MXC, DOL, PES
+````
+
+We now build holistic representations for the United States and Mexico by binding each concept
+(country, capital, money) to its specific instance and then adding them together.
+
+````@example whats-the-dollar-of-mexico
 USTATES = (COUNTRY * USA) + (CAPITAL * WDC) + (MONEY * DOL)
-MEXICO  = (COUNTRY * MEX) + (CAPITAL * MXC) + (MONEY * PES)
+MEXICO = (COUNTRY * MEX) + (CAPITAL * MXC) + (MONEY * PES)
+
+USTATES, MEXICO
 ````
+
+These composite hypervectors encode all the information about each country in a single vector.
+The `Base.isapprox` function or `≈` operator checks if two hypervectors are approximately equal
+(i.e., similar).
 
 ````@example whats-the-dollar-of-mexico
 USTATES ≈ MEXICO
 ````
 
-If we now pair USTATES with MEXICO, we get a bundle that pairs USA with Mexico, Washington DC
-with Mexico City, and dollar with peso, plus noise:
+By binding (represented by the `*` operator) the holistic representations of USA and Mexico, we
+create a new hypervector that encodes the relationships between their respective elements: USA
+with Mexico, Washington DC with Mexico City, and dollar with peso, plus some noise due to the
+high-dimensional operations.
 
 ````@example whats-the-dollar-of-mexico
 F_UM = USTATES * MEXICO
 ````
 
-What in Mexico corresponds to United States' dollar:
+````@example whats-the-dollar-of-mexico
+F_UM ≈ (USA * MEX) + (WDC * MXC) + (DOL * PES)
+````
+
+To answer Kanerva's question "What in Mexico corresponds to United States' dollar?", we unbind
+(represented again by the `*` operator) the dollar hypervector with the USA-Mexico relationship
+vector. The result should be similar to the peso hypervector.
 
 ````@example whats-the-dollar-of-mexico
 DOL * F_UM ≈ PES
 ````
 
-````@example whats-the-dollar-of-mexico
-SWE = BipolarHDV()
-STO = BipolarHDV()
-KRO = BipolarHDV()
+Let's add another country, Sweden, with its capital and currency.
 
-SWEDEN = (COUNTRY * SWE) + (CAPITAL * STO) + (MONEY * KRO)
+````@example whats-the-dollar-of-mexico
+SWE = BipolarHV(:sweden)
+STO = BipolarHV(:stockholm)
+SEK = BipolarHV(:krona)
+
+SWEDEN = (COUNTRY * SWE) + (CAPITAL * STO) + (MONEY * SEK)
 ````
+
+We can now explore more complex relationships by binding and combining these holistic representations.
+For example, `F_SU`encodes the relationship between Sweden and USA, and F_SM between Sweden and Mexico.
 
 ````@example whats-the-dollar-of-mexico
 F_UM = USTATES * MEXICO
 F_SU = SWEDEN * USTATES
 F_SM = SWEDEN * MEXICO
+````
 
+Combining these relationship vectors allows us to infer new relationships, such as how Sweden relates
+to Mexico via the USA.
+
+````@example whats-the-dollar-of-mexico
 F_SU * F_UM ≈ F_SM
 ````
+
+We can also directly query for corresponding elements between countries:
+
+For example, what is the currency of Mexico, given the currency of the USA?
 
 ````@example whats-the-dollar-of-mexico
 USTATES * DOL ≈ MEXICO * PES
 ````
 
+Or, what is the currency of Mexico, given the USA and its currency?
+
 ````@example whats-the-dollar-of-mexico
 USTATES * DOL * MEXICO ≈ PES
 ````
 
+Similarly, we can query for Sweden's currency using the same approach.
+
 ````@example whats-the-dollar-of-mexico
-USTATES * DOL * MEXICO ≈ KRO
+USTATES * DOL * MEXICO ≈ SEK
 ````
+
+Or, recover the original currency of the USA.
 
 ````@example whats-the-dollar-of-mexico
 USTATES * DOL * MEXICO ≈ DOL
 ````
+
+This tutorial demonstrates how hyperdimensional computing enables analogical reasoning and flexible
+querying by representing and manipulating concepts as high-dimensional vectors.
 
 ---
 

--- a/ext/UnicodePlotting.jl
+++ b/ext/UnicodePlotting.jl
@@ -1,33 +1,43 @@
 module UnicodePlotting
 
-
 #=
-Representing the hypervectors using pretty printing
-and a custom plotting recipe
+Rich terminal display for hypervectors based on UnicodePlots.
+
+This extension deliberately defines NO `Base.show` methods: the single `show`
+method for `AbstractHV` lives in src/representations.jl and delegates to
+`_show_rich` here when the extension is loaded. Defining the same `show`
+signature in both places would be method overwriting, which is forbidden during
+precompilation.
 =#
 
-using StatsBase, UnicodePlots
+using UnicodePlots
 using HyperdimensionalComputing
+using HyperdimensionalComputing: AbstractHV
+import HyperdimensionalComputing: unicodeheatmap, unicodehistogram
+
+# Values used for plotting: the element values, or the phases for FHRR.
+plotvalues(hv::AbstractHV) = collect(hv)
+plotvalues(hv::FHRR) = angle.(hv.v)
 
 function unicodeheatmap(hv::AbstractHV)
-    N = length(hv)
-    nsq = floor(Int, sqrt(N))
-    Np = nsq^2
-    return heatmap(reshape(hv[1:Np], (nsq, nsq)))
+    vals = plotvalues(hv)
+    nsq = floor(Int, sqrt(length(vals)))
+    return heatmap(reshape(vals[1:(nsq^2)], (nsq, nsq)))
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", hv::AbstractHV)
-    println(io, "$(length(hv))-element $(typeof(hv))")
-    println(io, "mean ± std : $(round(mean(hv), digits = 3)) ± $(round(std(hv), digits = 3))")
-    println(io, UnicodePlotting.histogram(hv.v))
-    return println(io, unicodeheatmap(hv))
+unicodehistogram(hv::AbstractHV) = histogram(plotvalues(hv))
+
+function unicodehistogram(hv::Union{BinaryHV, BipolarHV, TernaryHV})
+    counts = Dict(string(x) => count(==(x), hv) for x in unique(collect(hv)))
+    return barplot(counts)
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", hv::Union{BinaryHV, BipolarHV})
-    counts = Dict(string(e) => count(==(e), hv) for e in unique(hv))
-    println(io, "$(length(hv))-element $(typeof(hv))")
-    println(io, barplot(counts))
-    return println(io, unicodeheatmap(hv))
+# Called by `Base.show(io, ::MIME"text/plain", ::AbstractHV)` in
+# src/representations.jl when this extension is loaded.
+function _show_rich(io::IO, ::MIME"text/plain", hv::AbstractHV)
+    println(io, summary(hv), ":")
+    println(io, unicodehistogram(hv))
+    return print(io, unicodeheatmap(hv))
 end
 
 end

--- a/src/HyperdimensionalComputing.jl
+++ b/src/HyperdimensionalComputing.jl
@@ -48,6 +48,14 @@ export multiset,
     decodelevel,
     convertlevel
 
+include("encode.jl")
+export encode,
+    AbstractEncoding,
+    KMer,
+    NGram,
+    Sequence,
+    BagOfSymbols
+
 include("inference.jl")
 export similarity,
     δ,

--- a/src/HyperdimensionalComputing.jl
+++ b/src/HyperdimensionalComputing.jl
@@ -16,6 +16,8 @@ export AbstractHV,
     FHRR
 
 include("representations.jl")
+export unicodeheatmap,
+    unicodehistogram
 
 include("operations.jl")
 export bundle,

--- a/src/encode.jl
+++ b/src/encode.jl
@@ -1,0 +1,198 @@
+#=
+encode.jl
+
+The encoder layer: turning raw data into hypervectors.
+
+Layer taxonomy of the package:
+- primitives   (operations.jl): bundle, bind, shift, perturbate
+- combinators  (encoding.jl):   multiset, ngrams, hashtable, ... — hypervectors
+                                in, hypervector out
+- encoders     (this file):     raw data in, hypervector out
+
+`encode(HV, x)` is the canonical token path; sequence strategies compose the
+token path with the existing combinators. Stateful encoders (random projection,
+level encoders) are a planned follow-up as an `AbstractEncoder{HV}` hierarchy
+whose instances will slot in as the first argument of `encode` — nothing here
+may claim `encode(::SomeState, ...)` for other purposes.
+=#
+
+"""
+    encode(HV::Type{<:AbstractHV}, x; D = 10_000, kwargs...)
+    encode(HV::Type{<:AbstractHV}, x, strategy::AbstractEncoding; D = 10_000, kwargs...)
+
+Encode raw data `x` as a `D`-dimensional hypervector of type `HV`.
+
+Without a strategy, this is the **token path**: one object, one hash, one
+hypervector. `x` is hashed and the hash seeds the hypervector, so encoding the
+same object twice yields the same hypervector, and distinct objects give
+quasi-orthogonal hypervectors. This holds for *any* `x`, including strings and
+collections: `encode(HV, "ACGT")` hashes the whole string as a single token.
+
+To encode a string (or any iterable of symbols) as a *sequence*, say so with a
+strategy: [`KMer`](@ref), [`NGram`](@ref), [`Sequence`](@ref) or
+[`BagOfSymbols`](@ref). Strategies are thin compositions of the token path with
+the combinators in `encoding.jl` (`multiset`, `ngrams`, `bundlesequence`).
+
+`HV(x)` is shorthand for `encode(HV, x)` for token-like `x`; every non-trivial
+encoding goes through `encode`. Extra keyword arguments (`distr`, `T`, ...) are
+forwarded to the `HV` constructor.
+
+# Examples
+
+```jldoctest
+julia> encode(BipolarHV, "cat") == encode(BipolarHV, "cat")   # deterministic
+true
+
+julia> encode(BipolarHV, "cat") == BipolarHV("cat")           # HV(x) is sugar
+true
+
+julia> length(encode(BinaryHV, 42; D = 100))   # numbers are fine as encode tokens
+100
+```
+
+Sequence strategies compose the token path with the combinators:
+
+```jldoctest
+julia> kmer = encode(BinaryHV, "ACGTAC", KMer(3); D = 64);
+
+julia> kmer == multiset([encode(BinaryHV, s; D = 64) for s in ["ACG", "CGT", "GTA", "TAC"]])
+true
+
+julia> kmer != encode(BinaryHV, "ACGTAC", NGram(3); D = 64)   # a different encoding
+true
+```
+
+# See also
+
+[`AbstractEncoding`](@ref), [`KMer`](@ref), [`NGram`](@ref), [`Sequence`](@ref),
+[`BagOfSymbols`](@ref)
+"""
+encode(HV::Type{<:AbstractHV}, x; kwargs...) = HV(; seed = hash(x), kwargs...)
+
+"""
+    AbstractEncoding
+
+Supertype of sequence-encoding strategies for [`encode`](@ref):
+[`KMer`](@ref), [`NGram`](@ref), [`Sequence`](@ref) and [`BagOfSymbols`](@ref).
+
+# Extending
+
+Adding a new strategy requires only a struct and one `encode` method:
+
+    struct EveryOther <: AbstractEncoding end
+
+    function HyperdimensionalComputing.encode(
+            HV::Type{<:AbstractHV}, x, ::EveryOther; kwargs...
+        )
+        return multiset([encode(HV, s; kwargs...) for s in collect(x)[1:2:end]])
+    end
+"""
+abstract type AbstractEncoding end
+
+"""
+    KMer(k)
+
+Sequence-encoding strategy: slide a window of length `k` over the sequence,
+treat every k-mer **substring as one atomic token**, hash it, and bundle the
+results with [`multiset`](@ref). This is the standard genomics/text encoding
+(k-mer profile) and resolves issue #53.
+
+Not the same operation as [`NGram`](@ref): `KMer` hashes each window as a
+whole, so `"AC"` and `"CA"` get unrelated hypervectors; `NGram` encodes the
+*symbols* and composes windows by shift-binding, so windows that share symbols
+share structure. The two produce different hypervectors with different
+properties — pick deliberately.
+
+# Examples
+
+```jldoctest
+julia> hv = encode(BinaryHV, "ACGT", KMer(2); D = 64);
+
+julia> hv == multiset([encode(BinaryHV, s; D = 64) for s in ["AC", "CG", "GT"]])
+true
+```
+"""
+struct KMer <: AbstractEncoding
+    k::Int
+    function KMer(k::Integer)
+        k ≥ 1 || throw(ArgumentError("k-mer length must be ≥ 1, got $k"))
+        return new(k)
+    end
+end
+
+"""
+    NGram(n)
+
+Sequence-encoding strategy: encode each **symbol** to a hypervector, compose
+every window of `n` consecutive symbols by shift-binding, and bundle the
+windows — i.e. the existing [`ngrams`](@ref) combinator applied to
+token-encoded symbols. See [`KMer`](@ref) for how this differs from k-mer
+hashing.
+
+# Examples
+
+```jldoctest
+julia> hv = encode(BinaryHV, "ACGT", NGram(2); D = 64);
+
+julia> hv == ngrams([encode(BinaryHV, c; D = 64) for c in "ACGT"], 2)
+true
+```
+"""
+struct NGram <: AbstractEncoding
+    n::Int
+    function NGram(n::Integer)
+        n ≥ 1 || throw(ArgumentError("n-gram size must be ≥ 1, got $n"))
+        return new(n)
+    end
+end
+
+"""
+    Sequence()
+
+Sequence-encoding strategy: encode each symbol to a hypervector and superpose
+them position-aware via [`bundlesequence`](@ref) (symbol `i` is shifted `i - 1`
+times). Similar sequences map to similar hypervectors; use [`KMer`](@ref) or
+[`NGram`](@ref) for local-window statistics instead.
+"""
+struct Sequence <: AbstractEncoding end
+
+"""
+    BagOfSymbols()
+
+Sequence-encoding strategy: encode each symbol to a hypervector and bundle them
+orderlessly with [`multiset`](@ref) — the position-free counterpart of
+[`Sequence`](@ref) (and the `n = 1` corner of [`NGram`](@ref)).
+"""
+struct BagOfSymbols <: AbstractEncoding end
+
+# The window tokens: SubStrings for strings (hash-compatible with the equal
+# String, and unicode-safe), tuples of symbols for everything else.
+function windows(s::AbstractString, k::Int)
+    idx = collect(eachindex(s))
+    n = length(idx)
+    k ≤ n || throw(ArgumentError("cannot take $k-mers of a sequence of length $n"))
+    return [SubString(s, idx[i], idx[i + k - 1]) for i in 1:(n - k + 1)]
+end
+
+function windows(x, k::Int)
+    v = collect(x)
+    n = length(v)
+    k ≤ n || throw(ArgumentError("cannot take $k-mers of a sequence of length $n"))
+    return [Tuple(v[i:(i + k - 1)]) for i in 1:(n - k + 1)]
+end
+
+function encode(HV::Type{<:AbstractHV}, x, enc::KMer; kwargs...)
+    return multiset([encode(HV, w; kwargs...) for w in windows(x, enc.k)])
+end
+
+function encode(HV::Type{<:AbstractHV}, x, enc::NGram; kwargs...)
+    return ngrams([encode(HV, s; kwargs...) for s in collect(x)], enc.n)
+end
+
+function encode(HV::Type{<:AbstractHV}, x, ::Sequence; kwargs...)
+    return bundlesequence([encode(HV, s; kwargs...) for s in collect(x)])
+end
+
+function encode(HV::Type{<:AbstractHV}, x, ::BagOfSymbols; kwargs...)
+    return multiset([encode(HV, s; kwargs...) for s in collect(x)])
+end

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -528,7 +528,9 @@ decoder = decodelevel(hvlevels, numvalues)
 decoder(hvlevels[17])  # value that closely matches the corresponding HV
 ```
 """
-function decodelevel(hvlevels::AbstractVector{<:AbstractHV}, numvalues)
+function decodelevel(hvlevels::AbstractVector{<:AbstractHV}, numvalues; testbound = false)
+    # `testbound` is accepted (and ignored) for symmetry with `encodelevel`, so
+    # that the generic instance-based methods can forward keywords to both.
     @assert length(hvlevels) == length(numvalues) "HV levels do not match numerical values"
     # construct the decoder
     function decoder(hv::AbstractHV)
@@ -538,7 +540,7 @@ function decodelevel(hvlevels::AbstractVector{<:AbstractHV}, numvalues)
     return decoder
 end
 
-decodelevel(hvlevels::AbstractVector{<:AbstractHV}, a::Number, b::Number) = decodelevel(hvlevels, range(a, b, length(hvlevels)))
+decodelevel(hvlevels::AbstractVector{<:AbstractHV}, a::Number, b::Number; testbound = false) = decodelevel(hvlevels, range(a, b, length(hvlevels)); testbound)
 
 decodelevel(HV, numvalues; testbound = false) = decodelevel(level(HV, length(numvalues)), numvalues; testbound)
 

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -10,19 +10,21 @@ Multiset of input hypervectors, bundles all the input hypervectors together.
 ```
 julia> vs = BinaryHV.('a':'j'; D = 10)  # a hypervector for each character
 10-element Vector{BinaryHV}:
- 10-element BinaryHV with 7 true and 3 false
  10-element BinaryHV with 5 true and 5 false
  10-element BinaryHV with 6 true and 4 false
- 10-element BinaryHV with 2 true and 8 false
+ 10-element BinaryHV with 3 true and 7 false
+ 10-element BinaryHV with 6 true and 4 false
  10-element BinaryHV with 3 true and 7 false
  10-element BinaryHV with 6 true and 4 false
  10-element BinaryHV with 4 true and 6 false
- 10-element BinaryHV with 2 true and 8 false
- 10-element BinaryHV with 2 true and 8 false
- 10-element BinaryHV with 6 true and 4 false
+ 10-element BinaryHV with 3 true and 7 false
+ 10-element BinaryHV with 5 true and 5 false
+ 10-element BinaryHV with 3 true and 7 false
 
 julia> multiset(vs)
 10-element BinaryHV with 3 true and 7 false:
+ 1
+ 0
  0
  0
  0
@@ -31,8 +33,6 @@ julia> multiset(vs)
  1
  0
  0
- 0
- 1
 ```
 
 # Extended help
@@ -71,12 +71,12 @@ Binding of multiple hypervectors, binds all the input hypervectors together.
 julia> vs = BinaryHV.('a':'j'; D = 10);  # a hypervector for each character
 
 julia> multibind(vs)
-10-element BinaryHV with 7 true and 3 false:
+10-element BinaryHV with 4 true and 6 false:
  1
  0
- 1
- 1
- 1
+ 0
+ 0
+ 0
  0
  1
  0
@@ -121,16 +121,16 @@ Bundling-based sequence. The first value is not permuted, the last value is perm
 julia> vs = BinaryHV.('a':'j'; D = 10);  # a hypervector for each character
 
 julia> bundlesequence(vs)
-10-element BinaryHV with 2 true and 8 false:
+10-element BinaryHV with 4 true and 6 false:
  0
  0
  0
  1
- 0
- 0
- 0
+ 1
  0
  1
+ 1
+ 0
  0
 ```
 
@@ -172,17 +172,17 @@ Binding-based sequence. The first value is not permuted, the last value is permu
 julia> vs = BinaryHV.('a':'j'; D = 10);  # a hypervector for each character
 
 julia> bindsequence(vs)
-10-element BinaryHV with 5 true and 5 false:
- 1
- 1
- 0
- 1
+10-element BinaryHV with 6 true and 4 false:
  1
  0
  0
  1
+ 1
  0
  0
+ 1
+ 1
+ 1
 ```
 
 # Extended help
@@ -227,15 +227,15 @@ julia> ks = BinaryHV.([:name, :age, :city]; D = 10);  # key hypervectors
 julia> vs = BinaryHV.(["Alice", "42", "Ghent"]; D = 10);  # value hypervectors
 
 julia> hashtable(ks, vs)
-10-element BinaryHV with 7 true and 3 false:
+10-element BinaryHV with 3 true and 7 false:
+ 0
+ 0
  0
  1
  1
  0
- 1
- 1
- 1
- 1
+ 0
+ 0
  1
  0
 ```
@@ -278,13 +278,13 @@ julia> us = BinaryHV.('a':'e'; D = 10);
 julia> vs = BinaryHV.('v':'z'; D = 10);
 
 julia> crossproduct(us, vs)
-10-element BinaryHV with 6 true and 4 false:
- 1
+10-element BinaryHV with 5 true and 5 false:
  0
  1
  0
- 0
  1
+ 0
+ 0
  1
  1
  1
@@ -331,17 +331,17 @@ Creates a hypervector with the _n_-gram statistics of the input.
 julia> vs = BinaryHV.('a':'j'; D = 10);  # a hypervector for each character
 
 julia> ngrams(vs)
-10-element BinaryHV with 4 true and 6 false:
+10-element BinaryHV with 5 true and 5 false:
+ 1
+ 0
+ 0
  1
  0
  1
  0
- 1
- 0
- 0
  0
  1
- 0
+ 1
 ```
 
 # Extended help
@@ -395,16 +395,16 @@ Graph for `source`-`target` pairs. Can be directed or undirected.
 julia> nodes = BinaryHV.('a':'d'; D = 10);  # a hypervector for each node
 
 julia> graph(nodes[[1, 1, 2, 3]], nodes[[2, 3, 4, 4]])  # edges a-b, a-c, b-d, c-d
-10-element BinaryHV with 5 true and 5 false:
- 0
- 1
- 1
+10-element BinaryHV with 2 true and 8 false:
  0
  1
  0
  0
+ 0
  1
- 1
+ 0
+ 0
+ 0
  0
 ```
 

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -8,31 +8,31 @@ Multiset of input hypervectors, bundles all the input hypervectors together.
 
 # Example
 ```
-julia> vs = [BinaryHV(10) for _ in 1:10]
+julia> vs = BinaryHV.('a':'j'; D = 10)  # a hypervector for each character
 10-element Vector{BinaryHV}:
- [0, 1, 0, 0, 1, 1, 0, 1, 1, 1]
- [1, 0, 1, 0, 0, 0, 1, 1, 1, 0]
- [0, 1, 0, 1, 0, 0, 1, 0, 0, 0]
- [0, 1, 0, 1, 1, 0, 1, 0, 1, 0]
- [1, 1, 0, 0, 1, 0, 1, 1, 1, 0]
- [0, 0, 1, 1, 1, 1, 0, 0, 1, 0]
- [0, 0, 0, 0, 1, 1, 0, 1, 1, 0]
- [1, 1, 1, 0, 1, 1, 0, 0, 1, 1]
- [1, 1, 0, 1, 1, 0, 0, 0, 0, 0]
- [1, 1, 0, 0, 0, 1, 1, 0, 0, 0]
+ 10-element BinaryHV with 7 true and 3 false
+ 10-element BinaryHV with 5 true and 5 false
+ 10-element BinaryHV with 6 true and 4 false
+ 10-element BinaryHV with 2 true and 8 false
+ 10-element BinaryHV with 3 true and 7 false
+ 10-element BinaryHV with 6 true and 4 false
+ 10-element BinaryHV with 4 true and 6 false
+ 10-element BinaryHV with 2 true and 8 false
+ 10-element BinaryHV with 2 true and 8 false
+ 10-element BinaryHV with 6 true and 4 false
 
 julia> multiset(vs)
-10-element BinaryHV:
+10-element BinaryHV with 3 true and 7 false:
  0
- 1
- 0
- 0
- 1
  0
  0
  0
  1
+ 1
  0
+ 0
+ 0
+ 1
 ```
 
 # Extended help
@@ -68,23 +68,10 @@ Binding of multiple hypervectors, binds all the input hypervectors together.
 
 # Examples
 ```
-julia> vs = [BinaryHV(10) for _ in 1:10]
-10-element Vector{BinaryHV}:
- [0, 1, 0, 0, 1, 1, 0, 1, 1, 1]
- [1, 0, 1, 0, 0, 0, 1, 1, 1, 0]
- [0, 1, 0, 1, 0, 0, 1, 0, 0, 0]
- [0, 1, 0, 1, 1, 0, 1, 0, 1, 0]
- [1, 1, 0, 0, 1, 0, 1, 1, 1, 0]
- [0, 0, 1, 1, 1, 1, 0, 0, 1, 0]
- [0, 0, 0, 0, 1, 1, 0, 1, 1, 0]
- [1, 1, 1, 0, 1, 1, 0, 0, 1, 1]
- [1, 1, 0, 1, 1, 0, 0, 0, 0, 0]
- [1, 1, 0, 0, 0, 1, 1, 0, 0, 0]
+julia> vs = BinaryHV.('a':'j'; D = 10);  # a hypervector for each character
 
 julia> multibind(vs)
-10-element BinaryHV:
- 1
- 1
+10-element BinaryHV with 7 true and 3 false:
  1
  0
  1
@@ -93,6 +80,8 @@ julia> multibind(vs)
  0
  1
  0
+ 1
+ 1
 ```
 
 # Extended help
@@ -129,31 +118,20 @@ Bundling-based sequence. The first value is not permuted, the last value is perm
 
 # Examples
 ```
-julia> vs = [BinaryHV(10) for _ in 1:10]
-10-element Vector{BinaryHV}:
- [0, 1, 0, 0, 1, 1, 0, 1, 1, 1]
- [1, 0, 1, 0, 0, 0, 1, 1, 1, 0]
- [0, 1, 0, 1, 0, 0, 1, 0, 0, 0]
- [0, 1, 0, 1, 1, 0, 1, 0, 1, 0]
- [1, 1, 0, 0, 1, 0, 1, 1, 1, 0]
- [0, 0, 1, 1, 1, 1, 0, 0, 1, 0]
- [0, 0, 0, 0, 1, 1, 0, 1, 1, 0]
- [1, 1, 1, 0, 1, 1, 0, 0, 1, 1]
- [1, 1, 0, 1, 1, 0, 0, 0, 0, 0]
- [1, 1, 0, 0, 0, 1, 1, 0, 0, 0]
+julia> vs = BinaryHV.('a':'j'; D = 10);  # a hypervector for each character
 
 julia> bundlesequence(vs)
-10-element BinaryHV:
- 0
- 1
- 0
- 0
- 0
+10-element BinaryHV with 2 true and 8 false:
  0
  0
  0
  1
+ 0
+ 0
+ 0
+ 0
  1
+ 0
 ```
 
 # Extended help
@@ -191,31 +169,20 @@ Binding-based sequence. The first value is not permuted, the last value is permu
 
 # Examples
 ```
-julia> vs = [BinaryHV(10) for _ in 1:10]
-10-element Vector{BinaryHV}:
- [0, 1, 0, 0, 1, 1, 0, 1, 1, 1]
- [1, 0, 1, 0, 0, 0, 1, 1, 1, 0]
- [0, 1, 0, 1, 0, 0, 1, 0, 0, 0]
- [0, 1, 0, 1, 1, 0, 1, 0, 1, 0]
- [1, 1, 0, 0, 1, 0, 1, 1, 1, 0]
- [0, 0, 1, 1, 1, 1, 0, 0, 1, 0]
- [0, 0, 0, 0, 1, 1, 0, 1, 1, 0]
- [1, 1, 1, 0, 1, 1, 0, 0, 1, 1]
- [1, 1, 0, 1, 1, 0, 0, 0, 0, 0]
- [1, 1, 0, 0, 0, 1, 1, 0, 0, 0]
+julia> vs = BinaryHV.('a':'j'; D = 10);  # a hypervector for each character
 
 julia> bindsequence(vs)
-10-element BinaryHV:
- 0
+10-element BinaryHV with 5 true and 5 false:
  1
  1
  0
  1
  1
  0
+ 0
  1
- 1
- 1
+ 0
+ 0
 ```
 
 # Extended help
@@ -255,34 +222,22 @@ to encode as hypervector.
 
 # Example
 ```
-julia> ks = [BinaryHV(10) for _ in 1:5]
-5-element Vector{BinaryHV}:
- [0, 0, 0, 1, 0, 1, 1, 0, 0, 0]
- [1, 0, 1, 0, 1, 0, 1, 0, 1, 1]
- [0, 0, 0, 0, 1, 1, 1, 0, 1, 1]
- [1, 0, 0, 0, 0, 1, 1, 0, 1, 0]
- [0, 1, 1, 1, 1, 0, 0, 1, 1, 1]
+julia> ks = BinaryHV.([:name, :age, :city]; D = 10);  # key hypervectors
 
-julia> vs = [BinaryHV(10) for _ in 1:5]
-5-element Vector{BinaryHV}:
- [0, 1, 0, 0, 1, 1, 0, 1, 0, 0]
- [1, 0, 1, 1, 1, 0, 1, 0, 0, 0]
- [0, 0, 0, 0, 0, 1, 1, 0, 1, 0]
- [0, 1, 1, 0, 0, 0, 0, 1, 0, 1]
- [0, 1, 1, 0, 0, 0, 1, 1, 0, 1]
+julia> vs = BinaryHV.(["Alice", "42", "Ghent"]; D = 10);  # value hypervectors
 
 julia> hashtable(ks, vs)
-10-element BinaryHV:
- 0
- 0
+10-element BinaryHV with 7 true and 3 false:
  0
  1
  1
  0
  1
+ 1
+ 1
+ 1
+ 1
  0
- 1
- 1
 ```
 
 # Extended help
@@ -318,34 +273,22 @@ Cross product between two sets of hypervectors.
 
 # Examples
 ```
-julia> us = [BinaryHV(10) for _ in 1:5]
-5-element Vector{BinaryHV}:
- [1, 1, 1, 1, 1, 0, 0, 1, 0, 0]
- [0, 1, 0, 0, 1, 1, 1, 0, 1, 0]
- [0, 1, 1, 1, 1, 0, 0, 1, 1, 1]
- [0, 1, 1, 0, 1, 0, 1, 1, 1, 0]
- [1, 0, 0, 1, 0, 0, 1, 1, 1, 1]
+julia> us = BinaryHV.('a':'e'; D = 10);
 
-julia> vs = [BinaryHV(10) for _ in 1:5]
-5-element Vector{BinaryHV}:
- [0, 1, 1, 1, 1, 1, 0, 1, 0, 0]
- [0, 0, 1, 0, 0, 1, 1, 0, 0, 1]
- [0, 0, 0, 0, 1, 0, 0, 1, 0, 1]
- [1, 0, 1, 1, 0, 1, 1, 1, 1, 1]
- [1, 0, 1, 0, 0, 1, 0, 1, 0, 1]
+julia> vs = BinaryHV.('v':'z'; D = 10);
 
 julia> crossproduct(us, vs)
-10-element BinaryHV:
- 0
- 0
+10-element BinaryHV with 6 true and 4 false:
  1
  0
  1
  0
  0
  1
- 0
  1
+ 1
+ 1
+ 0
 ```
 
 # Extended help
@@ -385,31 +328,20 @@ Creates a hypervector with the _n_-gram statistics of the input.
 
 # Examples
 ```
-julia> vs = [BinaryHV(10) for _ in 1:10]
-10-element Vector{BinaryHV}:
- [0, 1, 0, 0, 1, 0, 1, 0, 0, 1]
- [0, 0, 1, 1, 1, 0, 0, 1, 1, 1]
- [0, 0, 1, 0, 0, 1, 1, 1, 0, 0]
- [1, 0, 0, 0, 1, 0, 0, 1, 1, 1]
- [0, 1, 0, 0, 1, 0, 1, 1, 0, 0]
- [1, 1, 1, 0, 1, 0, 0, 1, 0, 1]
- [1, 0, 0, 0, 1, 0, 0, 1, 1, 0]
- [0, 1, 0, 1, 0, 0, 0, 1, 1, 0]
- [0, 0, 0, 1, 1, 1, 1, 0, 0, 1]
- [1, 1, 0, 0, 0, 1, 1, 1, 0, 1]
+julia> vs = BinaryHV.('a':'j'; D = 10);  # a hypervector for each character
 
 julia> ngrams(vs)
-10-element BinaryHV:
- 1
- 1
- 1
- 1
- 1
+10-element BinaryHV with 4 true and 6 false:
  1
  0
  1
  0
  1
+ 0
+ 0
+ 0
+ 1
+ 0
 ```
 
 # Extended help
@@ -459,6 +391,22 @@ Graph for `source`-`target` pairs. Can be directed or undirected.
 - `directed::Bool = false`: Whether the graph is directed or not
 
 # Example
+```
+julia> nodes = BinaryHV.('a':'d'; D = 10);  # a hypervector for each node
+
+julia> graph(nodes[[1, 1, 2, 3]], nodes[[2, 3, 4, 4]])  # edges a-b, a-c, b-d, c-d
+10-element BinaryHV with 5 true and 5 false:
+ 0
+ 1
+ 1
+ 0
+ 1
+ 0
+ 0
+ 1
+ 1
+ 0
+```
 
 # Extended help
 

--- a/src/inference.jl
+++ b/src/inference.jl
@@ -81,7 +81,7 @@ similarity(u::AbstractHV; kwargs...) = v -> similarity(u, v; kwargs...)
 
 Alias for `similarity`. See `similarity` for the main documentation.
 """
-δ = similarity
+const δ = similarity
 
 
 nearest_neighbor(u::AbstractHV, collection; kwargs...) =

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -302,46 +302,46 @@ end
 
 
 # Perturbation
-function randbv(n::Int, m::Int; rng::AbstractRNG = Random.GLOBAL_RNG)
+function randbv(n::Int, m::Int; rng::AbstractRNG = Random.default_rng())
     v = falses(n)
     v[1:m] .= true
     return shuffle!(rng, v)
 end
 
-function randbv(n::Int, p::Number; rng::AbstractRNG = Random.GLOBAL_RNG)
+function randbv(n::Int, p::Number; rng::AbstractRNG = Random.default_rng())
     @assert 0 ≤ p ≤ 1 "p should be a valid probability"
     return randbv(n, round(Int, p * n); rng = rng)
 end
 
-function randbv(n::Int, I; rng::AbstractRNG = Random.GLOBAL_RNG)
+function randbv(n::Int, I; rng::AbstractRNG = Random.default_rng())
     v = falses(n)
     v[I] .= true
     return v
 end
 
-function perturbate!(::Type{HVByteVec}, hv::HV, I, dist = eldist(hv); rng::AbstractRNG = Random.GLOBAL_RNG) where {HV <: AbstractHV}
+function perturbate!(::Type{HVByteVec}, hv::HV, I, dist = eldist(hv); rng::AbstractRNG = Random.default_rng()) where {HV <: AbstractHV}
     hv.v[I] .= rand(rng, dist, length(I))
     return hv
 end
 
-function perturbate!(::Type{HVByteVec}, hv::HV, M::BitVector, dist = eldist(hv); rng::AbstractRNG = Random.GLOBAL_RNG) where {HV <: AbstractHV}
+function perturbate!(::Type{HVByteVec}, hv::HV, M::BitVector, dist = eldist(hv); rng::AbstractRNG = Random.default_rng()) where {HV <: AbstractHV}
     hv.v[M] .= rand(rng, dist, sum(M))
     return hv
 end
 
-function perturbate!(::Type{HVByteVec}, hv::HV, p::Number, args...; rng::AbstractRNG = Random.GLOBAL_RNG) where {HV <: AbstractHV}
+function perturbate!(::Type{HVByteVec}, hv::HV, p::Number, args...; rng::AbstractRNG = Random.default_rng()) where {HV <: AbstractHV}
     return perturbate!(hv, randbv(length(hv), p; rng = rng), args...; rng = rng)
 end
 
-function perturbate!(::Type{HVBitVec}, hv::AbstractHV, binargs; rng::AbstractRNG = Random.GLOBAL_RNG)
+function perturbate!(::Type{HVBitVec}, hv::AbstractHV, binargs; rng::AbstractRNG = Random.default_rng())
     n = length(hv)
     M = randbv(n, binargs; rng = rng)
     hv.v .⊻= M
     return hv
 end
 
-perturbate!(hv, args...; rng::AbstractRNG = Random.GLOBAL_RNG) = perturbate!(vectype(hv), hv, args...; rng = rng)
-perturbate(hv::AbstractHV, args...; rng::AbstractRNG = Random.GLOBAL_RNG, kwargs...) = perturbate!(copy(hv), args...; rng = rng, kwargs...)
+perturbate!(hv, args...; rng::AbstractRNG = Random.default_rng()) = perturbate!(vectype(hv), hv, args...; rng = rng)
+perturbate(hv::AbstractHV, args...; rng::AbstractRNG = Random.default_rng(), kwargs...) = perturbate!(copy(hv), args...; rng = rng, kwargs...)
 
 # OTHER
 # -----

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -355,6 +355,19 @@ function perturbate!(::Type{HVByteVec}, hv::HV, p::Number, args...; rng::Abstrac
     return perturbate!(hv, randbv(length(hv), p; rng = rng), args...; rng = rng)
 end
 
+# FHRR elements live on the complex unit circle, so perturbation resamples the
+# phase at the selected positions instead of drawing from `eldist` (which would
+# produce invalid, non-unit-modulus elements).
+function perturbate!(::Type{HVByteVec}, hv::FHRR{Complex{R}}, I::AbstractVector{<:Integer}; rng::AbstractRNG = Random.default_rng()) where {R}
+    hv.v[I] .= exp.(2π * im .* rand(rng, R, length(I)))
+    return hv
+end
+
+function perturbate!(::Type{HVByteVec}, hv::FHRR{Complex{R}}, M::BitVector; rng::AbstractRNG = Random.default_rng()) where {R}
+    hv.v[M] .= exp.(2π * im .* rand(rng, R, sum(M)))
+    return hv
+end
+
 function perturbate!(::Type{HVBitVec}, hv::AbstractHV, binargs; rng::AbstractRNG = Random.default_rng())
     n = length(hv)
     M = randbv(n, binargs; rng = rng)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -276,7 +276,11 @@ end
 
 
 # Comparison
-Base.isequal(v::AbstractHV, u::AbstractHV) = v.v == u.v
+# Fast same-type equality via storage (bits <-> elements is a bijection per
+# type). Cross-type comparisons deliberately fall back to Base, which compares
+# element values — so a BinaryHV never equals a BipolarHV just because the
+# underlying bits match.
+Base.isequal(u::HV, v::HV) where {HV <: AbstractHV} = isequal(u.v, v.v)
 
 """
     Base.isapprox(u::AbstractHV, v::AbstractHV, atol=length(u)/100, ptol=0.01)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -276,11 +276,23 @@ end
 
 
 # Comparison
-# Fast same-type equality via storage (bits <-> elements is a bijection per
-# type). Cross-type comparisons deliberately fall back to Base, which compares
-# element values — so a BinaryHV never equals a BipolarHV just because the
-# underlying bits match.
+# Hypervectors of DIFFERENT types are never equal, even when their element
+# values coincide numerically (`true == 1` would otherwise make an all-true
+# BinaryHV equal an all-+1 BipolarHV, whose stored bits are the exact
+# opposite). Within one type, equality compares storage — a bijection to the
+# elements for every type — and TernaryHV{Int8} == TernaryHV{Int64} etc. still
+# compare by value via the family methods. Comparisons against plain
+# AbstractVectors keep Base's elementwise semantics, and hashing stays on the
+# AbstractArray element-based fallback so that `isequal(hv, v::Vector)` implies
+# equal hashes (a type-salted hash would break that contract).
+Base.:(==)(::AbstractHV, ::AbstractHV) = false
+Base.isequal(::AbstractHV, ::AbstractHV) = false
+Base.:(==)(u::HV, v::HV) where {HV <: AbstractHV} = u.v == v.v
 Base.isequal(u::HV, v::HV) where {HV <: AbstractHV} = isequal(u.v, v.v)
+for T in (:TernaryHV, :RealHV, :GradedHV, :GradedBipolarHV, :FHRR)
+    @eval Base.:(==)(u::$T, v::$T) = u.v == v.v
+    @eval Base.isequal(u::$T, v::$T) = isequal(u.v, v.v)
+end
 
 """
     Base.isapprox(u::AbstractHV, v::AbstractHV, atol=length(u)/100, ptol=0.01)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -190,7 +190,8 @@ Base.:+(u::HV, v::AbstractArray...) where {HV <: AbstractHV} = bundle((u, v...))
 
 Bind (associate) hypervectors into a single hypervector that is dissimilar to its
 inputs while preserving distances. Overloaded as the `*` operator and inverted by
-[`unbind`](@ref) (`/`).
+[`unbind`](@ref) (`/`) — except for [`RealHV`](@ref), whose binding is not exactly
+invertible.
 
 The binding rule depends on the hypervector type: XOR of the stored bits, which is
 self-inverse ([`BinaryHV`](@ref), [`BipolarHV`](@ref)), elementwise multiplication
@@ -214,15 +215,36 @@ Base.bind(hvs::AbstractVector{HV}) where {HV <: AbstractHV} = prod(hvs)
 
 
 """
-    unbind(hv1::HV, hv2::HV)
+    unbind(hv1, hv2)
 
-Unbinds `hv2` from `hv1`. For many types of hypervectors, the binding operator is
-idempotent, i.e., `u * v * v == u`.
+Unbind `hv2` from `hv1`, inverting [`bind`](@ref): `unbind(bind(x, y), y)` recovers
+`x`. Overloaded as the `/` operator.
 
-Aliases with `/`.
+For the XOR- and multiplication-based types ([`BinaryHV`](@ref), [`BipolarHV`](@ref),
+[`TernaryHV`](@ref)) binding is self-inverse, so `unbind` is simply `bind`; the same
+fallback gives approximate fuzzy unbinding for [`GradedHV`](@ref) and
+[`GradedBipolarHV`](@ref). [`FHRR`](@ref) unbinds exactly via elementwise complex
+division.
+
+!!! warning
+    Real-valued MAP binding is not exactly invertible, so `unbind` **throws** for
+    [`RealHV`](@ref). Recover bound information with [`similarity`](@ref) against
+    candidate hypervectors, or use [`FHRR`](@ref) or [`BipolarHV`](@ref) if you
+    need exact unbinding.
+
+# See also
+
+[`bind`](@ref), [`bundle`](@ref), [`similarity`](@ref)
 """
 unbind(hv1::HV, hv2::HV) where {HV <: AbstractHV} = bind(hv1, hv2)
-unbind(hv1::HV, hv2::HV) where {HV <: Union{RealHV, FHRR}} = HV(hv1.v ./ hv2.v)
+unbind(hv1::FHRR, hv2::FHRR) = FHRR(hv1.v ./ hv2.v)
+unbind(::RealHV, ::RealHV) = throw(
+    ArgumentError(
+        "real-valued MAP binding is not exactly invertible; recover bound " *
+            "information with `similarity` against candidate hypervectors, or use " *
+            "`FHRR` or `BipolarHV` if you need exact unbinding"
+    )
+)
 Base.:/(hv1::HV, hv2::HV) where {HV <: AbstractHV} = unbind(hv1, hv2)
 
 

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -127,28 +127,28 @@ function bundle(
 end
 
 # realhv: just add + rescale with sqrt m
-function bundle(::RealHV, hdvs, r)
+function bundle(hv1::RealHV, hdvs, r)
     m = 0
     for hv in hdvs
         r .+= hv.v
         m += 1
     end
     r ./= sqrt(m)
-    return RealHV(r)
+    return RealHV(r, hv1.distr)
 end
 
-function bundle(::GradedHV, hdvs, r)
+function bundle(hv1::GradedHV, hdvs, r)
     for hv in hdvs
         r .= three_pi.(r, hv.v)
     end
-    return GradedHV(r)
+    return GradedHV(r, hv1.distr)
 end
 
-function bundle(::GradedBipolarHV, hdvs, r)
+function bundle(hv1::GradedBipolarHV, hdvs, r)
     for hv in hdvs
         r .= three_pi_bipol.(r, hv.v)
     end
-    return GradedBipolarHV(r)
+    return GradedBipolarHV(r, hv1.distr)
 end
 
 function bundle(::FHRR, hdvs, r)
@@ -206,9 +206,9 @@ Base.bind(hv1::HV, hv2::HV) where {HV <: AbstractHV} = HV(hv1.v .* hv2.v)  # def
 Base.bind(hv1::BinaryHV, hv2::BinaryHV) = BinaryHV(hv1.v .⊻ hv2.v)
 Base.bind(hv1::BipolarHV, hv2::BipolarHV) = BipolarHV(hv1.v .⊻ hv2.v)
 Base.bind(hv1::TernaryHV, hv2::TernaryHV) = TernaryHV(hv1.v .* hv2.v)
-Base.bind(hv1::RealHV, hv2::RealHV) = RealHV(hv1.v .* hv2.v)
-Base.bind(hv1::GradedHV, hv2::GradedHV) = GradedHV(fuzzy_xor.(hv1.v, hv2.v))
-Base.bind(hv1::GradedBipolarHV, hv2::GradedBipolarHV) = GradedBipolarHV(fuzzy_xor_bipol.(hv1.v, hv2.v))
+Base.bind(hv1::RealHV, hv2::RealHV) = RealHV(hv1.v .* hv2.v, hv1.distr)
+Base.bind(hv1::GradedHV, hv2::GradedHV) = GradedHV(fuzzy_xor.(hv1.v, hv2.v), hv1.distr)
+Base.bind(hv1::GradedBipolarHV, hv2::GradedBipolarHV) = GradedBipolarHV(fuzzy_xor_bipol.(hv1.v, hv2.v), hv1.distr)
 Base.bind(hv1::FHRR, hv2::FHRR) = FHRR(hv1.v .* hv2.v)
 Base.:*(hv1::HV, hv2::HV) where {HV <: AbstractHV} = bind(hv1, hv2)
 Base.bind(hvs::AbstractVector{HV}) where {HV <: AbstractHV} = prod(hvs)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -252,7 +252,7 @@ Base.:/(hv1::HV, hv2::HV) where {HV <: AbstractHV} = unbind(hv1, hv2)
 # --------
 
 # Shifting / Permutation
-shift!(hv::AbstractHV, k = 1) = circshift!(hv.v, k)
+shift!(hv::AbstractHV, k = 1) = (circshift!(hv.v, k); hv)
 
 function shift(hv::AbstractHV, k = 1)
     r = similar(hv)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -123,7 +123,8 @@ function bundle(
         r .+= hv.v
     end
     normalize && clamp!(r, -1, 1)
-    return TernaryHV(r)
+    # inner constructor: bundling may exceed the ternary domain by design
+    return TernaryHV{eltype(r)}(r)
 end
 
 # realhv: just add + rescale with sqrt m
@@ -205,7 +206,7 @@ self-inverse ([`BinaryHV`](@ref), [`BipolarHV`](@ref)), elementwise multiplicati
 Base.bind(hv1::HV, hv2::HV) where {HV <: AbstractHV} = HV(hv1.v .* hv2.v)  # default
 Base.bind(hv1::BinaryHV, hv2::BinaryHV) = BinaryHV(hv1.v .⊻ hv2.v)
 Base.bind(hv1::BipolarHV, hv2::BipolarHV) = BipolarHV(hv1.v .⊻ hv2.v)
-Base.bind(hv1::TernaryHV, hv2::TernaryHV) = TernaryHV(hv1.v .* hv2.v)
+Base.bind(hv1::TernaryHV, hv2::TernaryHV) = (v = hv1.v .* hv2.v; TernaryHV{eltype(v)}(v))  # inner: operands may hold accumulated counts
 Base.bind(hv1::RealHV, hv2::RealHV) = RealHV(hv1.v .* hv2.v, hv1.distr)
 Base.bind(hv1::GradedHV, hv2::GradedHV) = GradedHV(fuzzy_xor.(hv1.v, hv2.v), hv1.distr)
 Base.bind(hv1::GradedBipolarHV, hv2::GradedBipolarHV) = GradedBipolarHV(fuzzy_xor_bipol.(hv1.v, hv2.v), hv1.distr)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -159,6 +159,21 @@ function bundle(::FHRR, hdvs, r)
     return FHRR(r)
 end
 
+"""
+    bundle(hvs; kwargs...)
+
+Bundle (superpose) a collection of hypervectors into a single hypervector that is
+similar to every input. Overloaded as the `+` operator.
+
+The aggregation rule depends on the hypervector type: majority vote with
+deterministic tie-breaking ([`BinaryHV`](@ref), [`BipolarHV`](@ref)), elementwise
+addition ([`TernaryHV`](@ref), [`RealHV`](@ref)), fuzzy aggregation
+([`GradedHV`](@ref), [`GradedBipolarHV`](@ref)) or phasor addition ([`FHRR`](@ref)).
+
+# See also
+
+[`bind`](@ref), [`similarity`](@ref)
+"""
 function bundle(hdvs; kwargs...)
     hv = first(hdvs)
     r = empty_vector(hv)
@@ -169,6 +184,23 @@ Base.:+(u::HV, v::AbstractArray...) where {HV <: AbstractHV} = bundle((u, v...))
 
 # BINDING
 # -------
+"""
+    bind(hv1, hv2)
+    bind(hvs::AbstractVector{<:AbstractHV})
+
+Bind (associate) hypervectors into a single hypervector that is dissimilar to its
+inputs while preserving distances. Overloaded as the `*` operator and inverted by
+[`unbind`](@ref) (`/`).
+
+The binding rule depends on the hypervector type: XOR of the stored bits, which is
+self-inverse ([`BinaryHV`](@ref), [`BipolarHV`](@ref)), elementwise multiplication
+([`TernaryHV`](@ref), [`RealHV`](@ref)), fuzzy XOR ([`GradedHV`](@ref),
+[`GradedBipolarHV`](@ref)) or complex multiplication ([`FHRR`](@ref)).
+
+# See also
+
+[`bundle`](@ref), [`unbind`](@ref), [`similarity`](@ref)
+"""
 Base.bind(hv1::HV, hv2::HV) where {HV <: AbstractHV} = HV(hv1.v .* hv2.v)  # default
 Base.bind(hv1::BinaryHV, hv2::BinaryHV) = BinaryHV(hv1.v .⊻ hv2.v)
 Base.bind(hv1::BipolarHV, hv2::BipolarHV) = BipolarHV(hv1.v .⊻ hv2.v)

--- a/src/representations.jl
+++ b/src/representations.jl
@@ -1,28 +1,48 @@
 #=
-Representing the hypervectors using pretty printing
-and a custom plotting recipe
+Pretty printing for hypervectors.
 
-See ext/UnicodePlotting.jl for extensions based on UnicodePlotting
+The plain path relies on Base's AbstractArray display machinery: we only provide
+type-specific `Base.summary` headers and let Base handle element alignment and
+`⋮` truncation. When the UnicodePlotting package extension is loaded (by loading
+UnicodePlots), `show` delegates to the extension's rich display, unless the IO
+context is `:compact`.
 =#
 
-function Base.show(io::IO, ::MIME"text/plain", hvs::AbstractVector{<:AbstractHV})
-    println(io, "$(length(hvs))-element $(typeof(hvs)):")
-    r = map(hvs) do hv
-        if hv isa BinaryHV
-            ntrue = count(hv.v)
-            nfalse = length(hv) - ntrue
-            " $(length(hv))-element $(typeof(hv)) with $(ntrue) true and $(nfalse) false"
-        elseif hv isa BipolarHV
-            npos = count(hv.v)
-            nneg = length(hv) - npos
-            " $(length(hv))-element $(typeof(hv)) with $(npos) positives and $(nneg) negatives"
-        elseif typeof(hv) == TernaryHV
-            counts = Dict(1 => count(>=(1), hv), -1 => count(<=(-1), hv), 0 => count(==(0), hv))
-            " $(length(hv))-element $(typeof(hv)) with $(counts[1]) positives, $(counts[0]) zeros, and $(counts[-1]) negatives"
-        else
-            " $(length(hv))-element $(typeof(hv)) with μ ± σ = $(round(mean(hv), digits = 3)) ± $(round(std(hv), digits = 3))"
-        end
+# Type-specific headers; Base's array printing does the rest.
+function Base.summary(io::IO, hv::BinaryHV)
+    ntrue = count(hv.v)
+    return print(io, length(hv), "-element ", typeof(hv), " with ", ntrue, " true and ", length(hv) - ntrue, " false")
+end
+
+function Base.summary(io::IO, hv::BipolarHV)
+    npos = count(hv.v)
+    return print(io, length(hv), "-element ", typeof(hv), " with ", npos, " positives and ", length(hv) - npos, " negatives")
+end
+
+function Base.summary(io::IO, hv::TernaryHV)
+    npos = count(>(0), hv.v)
+    nneg = count(<(0), hv.v)
+    return print(io, length(hv), "-element ", typeof(hv), " with ", npos, " positives, ", length(hv) - npos - nneg, " zeros, and ", nneg, " negatives")
+end
+
+function Base.summary(io::IO, hv::AbstractHV)
+    return print(io, length(hv), "-element ", typeof(hv), " with μ ± σ = ", round(mean(hv), digits = 3), " ± ", round(std(hv), digits = 3))
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", hv::AbstractHV)
+    ext = Base.get_extension(@__MODULE__, :UnicodePlotting)
+    if ext === nothing || get(io, :compact, false)::Bool
+        # standard Julia array display with the custom `summary` header
+        return invoke(show, Tuple{IO, MIME"text/plain", AbstractArray}, io, mime, hv)
+    else
+        return ext._show_rich(io, mime, hv)
     end
+end
+
+# Vectors of hypervectors: one summary line per hypervector.
+function Base.show(io::IO, ::MIME"text/plain", hvs::AbstractVector{<:AbstractHV})
+    println(io, summary(hvs), ":")
+    r = [" " * summary(hv) for hv in hvs]
 
     rows = displaysize(io)[1]
     if length(r) <= max(rows - 4, 0)
@@ -36,53 +56,33 @@ function Base.show(io::IO, ::MIME"text/plain", hvs::AbstractVector{<:AbstractHV}
     return print(io, join([first(r, chunksize); " ⋮"; last(r, chunksize)], '\n'))
 end
 
-function Base.show(io::IO, ::MIME"text/plain", hv::AbstractHV)
-    # NOTE: Based off https://github.com/JuliaLang/julia/blob/cf40898d56a5b32c6a2e97f61355440df36a7357/base/arrayshow.jl#L363
-    # Fast return for empty hypervectors
-    if isempty(hv)
-        if get(io, :compact, false)::Bool
-            return print(io, typeof(hv))
-        else
-            return println(io, "0-element $(typeof(hv)):")
-        end
-    end
+"""
+    unicodeheatmap(hv::AbstractHV)
 
-    # 1) show summary before setting :compact
-    if hv isa BinaryHV
-        ntrue = count(hv.v)
-        nfalse = length(hv) - ntrue
-        print(io, "$(length(hv))-element $(typeof(hv)) with $(ntrue) true and $(nfalse) false")
-    elseif hv isa BipolarHV
-        npos = count(hv.v)
-        nneg = length(hv) - npos
-        print(io, "$(length(hv))-element $(typeof(hv)) with $(npos) positives and $(nneg) negatives")
-    elseif typeof(hv) == TernaryHV
-        counts = Dict(1 => count(>=(1), hv), -1 => count(<=(-1), hv), 0 => count(==(0), hv))
-        print(io, "$(length(hv))-element $(typeof(hv)) with $(counts[1]) positives, $(counts[0]) zeros, and $(counts[-1]) negatives")
-    else
-        print(io, "$(length(hv))-element $(typeof(hv)) with μ ± σ = $(round(mean(hv), digits = 3)) ± $(round(std(hv), digits = 3))")
-    end
+Render a hypervector as a square unicode heatmap of its leading `⌊√D⌋²` elements
+(phases for [`FHRR`](@ref)).
 
-    print(io, ":")
+Only available when UnicodePlots is loaded (`using UnicodePlots`); implemented in
+the UnicodePlotting package extension.
 
-    # 2) compute new IOContext
-    if !haskey(io, :compact) && length(axes(hv, 2)) > 1
-        io = IOContext(io, :compact => true)
-    end
-    if get(io, :limit, false)::Bool && eltype(hv) === Method
-        io = IOContext(io, :limit => false)
-    end
+# See also
 
-    if get(io, :limit, false)::Bool && displaysize(io)[1] - 4 <= 0
-        print(io, " …")
-    else
-        println(io)
-    end
+[`unicodehistogram`](@ref)
+"""
+function unicodeheatmap end
 
-    # 3) update typeinfo
-    io = IOContext(io, :typeinfo => eltype(hv))
+"""
+    unicodehistogram(hv::AbstractHV)
 
-    # 4) show actual content
-    recur_io = IOContext(io, :SHOWN_SET => hv)
-    return Base.print_array(recur_io, hv)
-end
+Render the distribution of a hypervector's elements as a unicode histogram
+(a bar plot of counts for the discrete types [`BinaryHV`](@ref), [`BipolarHV`](@ref)
+and [`TernaryHV`](@ref); phases for [`FHRR`](@ref)).
+
+Only available when UnicodePlots is loaded (`using UnicodePlots`); implemented in
+the UnicodePlotting package extension.
+
+# See also
+
+[`unicodeheatmap`](@ref)
+"""
+function unicodehistogram end

--- a/src/representations.jl
+++ b/src/representations.jl
@@ -15,8 +15,9 @@ function Base.summary(io::IO, hv::BinaryHV)
 end
 
 function Base.summary(io::IO, hv::BipolarHV)
-    npos = count(hv.v)
-    return print(io, length(hv), "-element ", typeof(hv), " with ", npos, " positives and ", length(hv) - npos, " negatives")
+    # stored bit true ↦ -1, so count(hv.v) counts the NEGATIVES
+    nneg = count(hv.v)
+    return print(io, length(hv), "-element ", typeof(hv), " with ", length(hv) - nneg, " positives and ", nneg, " negatives")
 end
 
 function Base.summary(io::IO, hv::TernaryHV)

--- a/src/representations.jl
+++ b/src/representations.jl
@@ -25,7 +25,10 @@ function Base.summary(io::IO, hv::TernaryHV)
     return print(io, length(hv), "-element ", typeof(hv), " with ", npos, " positives, ", length(hv) - npos - nneg, " zeros, and ", nneg, " negatives")
 end
 
-function Base.summary(io::IO, hv::AbstractHV)
+# μ ± σ is informative for real-valued elements; for FHRR (complex points on the
+# unit circle) the mean/std carry no information, so FHRR intentionally has no
+# summary override and gets Base's plain "N-element FHRR{...}" header.
+function Base.summary(io::IO, hv::Union{RealHV, GradedHV, GradedBipolarHV})
     return print(io, length(hv), "-element ", typeof(hv), " with μ ± σ = ", round(mean(hv), digits = 3), " ± ", round(std(hv), digits = 3))
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -64,7 +64,9 @@ Some types extend this interface with type-specific keywords, e.g. `distr` for
 `hv[1:3]`, `hv[[1, 4]]`, logical masks — returns a plain `Vector` of element
 values, *not* a new hypervector: information in a hypervector is distributed over
 all `D` dimensions, so a slice is not itself a meaningful hypervector.
-Hypervectors are immutable; there is no `setindex!`.
+Hypervectors are immutable; there is no `setindex!`. Equality (`==`/`isequal`)
+holds only between hypervectors of the same type — a `BinaryHV` never equals a
+`BipolarHV` — while comparison against plain vectors is elementwise.
 
 # Examples
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -101,6 +101,9 @@ LinearAlgebra.norm(hv::AbstractHV) = norm(hv.v)
 normalize!(hv::AbstractHV) = hv
 normalize(hv::AbstractHV) = (c = copy(hv); normalize!(c); c)
 
+# Types that carry an element distribution (`distr` field) override the
+# instance method so that e.g. `perturbate` resamples from the vector's own
+# distribution, not the type default.
 eldist(hv::AbstractHV) = eldist(typeof(hv))
 empty_vector(hv::AbstractHV) = zero(hv.v)
 
@@ -544,6 +547,7 @@ function normalize!(hv::RealHV)
     return hv
 end
 eldist(::Type{<:RealHV}) = Normal()
+eldist(hv::RealHV) = hv.distr
 
 
 # -------------------------------------------------------------------------------------- GradedHV
@@ -631,6 +635,7 @@ Base.similar(hv::GradedHV) = GradedHV(; D = length(hv), distr = hv.distr)
 Base.zeros(hv::GradedHV) = fill!(similar(hv.v), one(eltype(hv.v)) / 2)
 normalize!(hv::GradedHV) = (clamp!(hv.v, 0, 1); hv)
 eldist(::Type{<:GradedHV}) = Beta(1, 1)
+eldist(hv::GradedHV) = hv.distr
 empty_vector(hv::GradedHV) = fill!(zero(hv.v), 0.5)
 
 
@@ -718,6 +723,7 @@ Base.copy(hv::GradedBipolarHV) = GradedBipolarHV(copy(hv.v), hv.distr)
 Base.similar(hv::GradedBipolarHV) = GradedBipolarHV(; D = length(hv), distr = hv.distr)
 normalize!(hv::GradedBipolarHV) = (clamp!(hv.v, -1, 1); hv)
 eldist(::Type{<:GradedBipolarHV}) = 2Beta(1, 1) - 1
+eldist(hv::GradedBipolarHV) = hv.distr
 
 # Fourier Holographic Reduced Representations
 # --------------------------------------------

--- a/src/types.jl
+++ b/src/types.jl
@@ -126,20 +126,23 @@ end
 """
     BipolarHV(; D = 10_000, seed = nothing, rng = default_rng())
     BipolarHV(this; D = 10_000)
+    BipolarHV(v::AbstractVector{<:Real})
     BipolarHV(v::AbstractVector{Bool})
-    BipolarHV(v::AbstractVector{<:Integer})
 
 A bipolar hypervector in the style of the Multiply-Add-Permute (MAP) vector symbolic
-architecture (Gayler, 1998). Elements are `±1`, stored
-compactly as a `BitVector`; indexing returns `±1`. Constructing from an integer
-vector maps positive entries to `+1` and the rest to `-1`.
+architecture (Gayler, 1998). Elements are `±1`, stored compactly as a `BitVector`
+with bit `true ↦ -1` and `false ↦ +1`, so that XOR on the stored bits is exactly
+the elementwise `±1` product.
 
-Under this architecture, `bind` is elementwise XOR of the stored bits and
-self-inverse (binding by the same hypervector twice undoes it; note that in the
-`±1` representation this is the *negated* elementwise product), `bundle` is a
+Constructing from a real vector takes the **sign** of each element; a zero element
+throws an `ArgumentError`, since a bipolar hypervector has no zero state — use
+[`TernaryHV`](@ref) for elements in `{-1, 0, +1}`. A `Bool` vector is the exception:
+it is interpreted as the **raw stored bits** (`true ↦ -1`), not as values.
+
+Under this architecture, `bind` is the elementwise product (XOR on the stored
+bits) and self-inverse — `x * x` is the all-`+1` identity — `bundle` is a
 majority vote across inputs with deterministic tie-breaking, and `similarity`
-defaults to cosine. Use [`TernaryHV`](@ref) for a (slightly less efficient)
-hypervector type that can contain zeros.
+defaults to cosine.
 
 The positional argument `this` is always the **object to encode** — it is hashed to
 seed the vector — and is *never* a dimension. Set dimensionality with the keyword
@@ -153,15 +156,15 @@ returns a plain `Vector`, not a hypervector.
 
 ```jldoctest
 julia> BipolarHV(; D = 8, rng = Xoshiro(42))
-8-element BipolarHV with 3 positives and 5 negatives:
- -1
- -1
- -1
- -1
+8-element BipolarHV with 5 positives and 3 negatives:
+  1
   1
   1
   1
  -1
+ -1
+ -1
+  1
 
 julia> BipolarHV("apple") == BipolarHV("apple")   # deterministic from hash
 true
@@ -210,7 +213,20 @@ function BipolarHV(
     return BipolarHV(bitrand(rng_instance, D))
 end
 
-BipolarHV(v::AbstractVector{<:Integer}) = BipolarHV(v .> 0)
+# Data constructor: the sign of each element decides the polarity. Zero has no
+# bipolar state, so it throws rather than letting a comparison operator decide
+# silently (that arbitrariness is what caused the polarity bug). Note that Bool
+# vectors do NOT take this path: they hit the inner constructor and are treated
+# as the raw stored bits.
+function BipolarHV(v::AbstractVector{<:Real})
+    any(iszero, v) && throw(
+        ArgumentError(
+            "bipolar hypervectors have no zero state; a zero element cannot be " *
+                "mapped to ±1. Use `TernaryHV` for hypervectors with elements in {-1, 0, +1}."
+        )
+    )
+    return BipolarHV(v .< 0)
+end
 
 # Helpers
 Base.getindex(hv::BipolarHV, i::Integer) = hv.v[i] ? -1 : 1

--- a/src/types.jl
+++ b/src/types.jl
@@ -91,19 +91,19 @@ julia> length(BinaryHV(:cat; D = 100))    # dimensionality is set with the keywo
 """
 abstract type AbstractHV{T} <: AbstractVector{T} end
 
-Base.copy(hv::HV) where {HV<:AbstractHV} = HV(copy(hv.v))
+Base.copy(hv::HV) where {HV <: AbstractHV} = HV(copy(hv.v))
 # Scalar indexing returns the element value; non-scalar indexing (ranges, index
 # vectors, logical masks) returns a plain Vector of element values, NOT a new
 # hypervector — a slice of a hypervector is not a meaningful hypervector.
 Base.getindex(hv::AbstractHV, i::Integer) = hv.v[i]
 Base.getindex(hv::AbstractHV, I::AbstractVector) = hv.v[I]
-Base.similar(hv::HV) where {HV<:AbstractHV} = HV(; D=length(hv))
+Base.similar(hv::HV) where {HV <: AbstractHV} = HV(; D = length(hv))
 Base.size(hv::AbstractHV) = size(hv.v)
 Base.sum(hv::AbstractHV) = sum(hv.v)
 
 LinearAlgebra.norm(hv::AbstractHV) = norm(hv.v)
 normalize!(hv::AbstractHV) = hv
-normalize(hv::AbstractHV) = (c=copy(hv); normalize!(c); c)
+normalize(hv::AbstractHV) = (c = copy(hv); normalize!(c); c)
 
 eldist(hv::AbstractHV) = eldist(typeof(hv))
 empty_vector(hv::AbstractHV) = zero(hv.v)
@@ -115,8 +115,8 @@ warn_integer_token(HV::Type, this) = nothing
 warn_integer_token(HV::Type, this::Bool) = nothing
 function warn_integer_token(HV::Type, this::Integer)
     @warn "`$HV($this)` encodes the *object* `$this` as a hypervector — the positional " *
-          "argument is never the dimensionality. Use `$HV(; D = $this)` to set the number " *
-          "of dimensions instead. (This warning is only shown once per session.)" maxlog = 1 _id = :hv_integer_token
+        "argument is never the dimensionality. Use `$HV(; D = $this)` to set the number " *
+        "of dimensions instead. (This warning is only shown once per session.)" maxlog = 1 _id = :hv_integer_token
     return nothing
 end
 
@@ -195,18 +195,18 @@ end
 
 # Outer constructors
 function BipolarHV(;
-    D::Integer=10_000,
-    seed::Union{Integer,Nothing}=nothing,
-    rng::AbstractRNG=Random.default_rng()
-)
+        D::Integer = 10_000,
+        seed::Union{Integer, Nothing} = nothing,
+        rng::AbstractRNG = Random.default_rng()
+    )
     rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return BipolarHV(bitrand(rng_instance, D))
 end
 
 function BipolarHV(
-    this::Any;
-    D::Integer=10_000
-)
+        this::Any;
+        D::Integer = 10_000
+    )
     warn_integer_token(BipolarHV, this)
     rng_instance = Xoshiro(hash(this))
     return BipolarHV(bitrand(rng_instance, D))
@@ -318,49 +318,49 @@ julia> normalize(x + y)
 
 - Gayler, R. W. (1998). Multiplicative Binding, Representation Operators & Analogy. In Advances in Analogy Research: Integration of Theory and Data from the Cognitive, Computational, and Neural Sciences, 1–4.
 """
-struct TernaryHV{T<:Integer} <: AbstractHV{T}
+struct TernaryHV{T <: Integer} <: AbstractHV{T}
     v::Vector{T}
 
     # Inner constructor for same type
-    TernaryHV{T}(v::AbstractVector{T}) where {T<:Integer} = new{T}(v)
+    TernaryHV{T}(v::AbstractVector{T}) where {T <: Integer} = new{T}(v)
     # Inner constructor for type conversion
-    TernaryHV{T}(v::AbstractVector{<:Integer}) where {T<:Integer} = new{T}(convert(Vector{T}, v))
+    TernaryHV{T}(v::AbstractVector{<:Integer}) where {T <: Integer} = new{T}(convert(Vector{T}, v))
 end
 
 # Outer constructor that infers type from input
-TernaryHV(v::AbstractVector{T}) where {T<:Integer} = TernaryHV{T}(v)
+TernaryHV(v::AbstractVector{T}) where {T <: Integer} = TernaryHV{T}(v)
 
 function TernaryHV(;
-    D::Integer=10_000,
-    seed::Union{Integer,Nothing}=nothing,
-    rng::AbstractRNG=Random.default_rng()
-)
+        D::Integer = 10_000,
+        seed::Union{Integer, Nothing} = nothing,
+        rng::AbstractRNG = Random.default_rng()
+    )
     rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return TernaryHV{Int}(rand(rng_instance, (-1, 1), D))
 end
 
 function TernaryHV(
-    this::Any;
-    D::Integer=10_000
-)
+        this::Any;
+        D::Integer = 10_000
+    )
     warn_integer_token(TernaryHV, this)
     rng_instance = Xoshiro(hash(this))
     return TernaryHV{Int}(rand(rng_instance, (-1, 1), D))
 end
 
 function TernaryHV{T}(;
-    D::Integer=10_000,
-    seed::Union{Integer,Nothing}=nothing,
-    rng::AbstractRNG=Random.default_rng()
-) where {T<:Integer}
+        D::Integer = 10_000,
+        seed::Union{Integer, Nothing} = nothing,
+        rng::AbstractRNG = Random.default_rng()
+    ) where {T <: Integer}
     rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return TernaryHV{T}(convert(Vector{T}, rand(rng_instance, (-1, 1), D)))
 end
 
 function TernaryHV{T}(
-    this::Any;
-    D::Integer=10_000
-) where {T<:Integer}
+        this::Any;
+        D::Integer = 10_000
+    ) where {T <: Integer}
     warn_integer_token(TernaryHV{T}, this)
     rng_instance = Xoshiro(hash(this))
     return TernaryHV{T}(convert(Vector{T}, rand(rng_instance, (-1, 1), D)))
@@ -368,7 +368,7 @@ end
 
 # Helpers
 Base.copy(hv::TernaryHV{T}) where {T} = TernaryHV{T}(copy(hv.v))
-Base.similar(hv::TernaryHV{T}) where {T} = TernaryHV{T}(; D=length(hv))
+Base.similar(hv::TernaryHV{T}) where {T} = TernaryHV{T}(; D = length(hv))
 normalize!(hv::TernaryHV) = (clamp!(hv.v, -1, 1); hv)
 eldist(::Type{<:TernaryHV}) = 2Bernoulli(0.5) - 1
 
@@ -441,18 +441,18 @@ struct BinaryHV <: AbstractHV{Bool}
 end
 
 function BinaryHV(;
-    D::Integer=10_000,
-    seed::Union{Integer,Nothing}=nothing,
-    rng::AbstractRNG=Random.default_rng()
-)
+        D::Integer = 10_000,
+        seed::Union{Integer, Nothing} = nothing,
+        rng::AbstractRNG = Random.default_rng()
+    )
     rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return BinaryHV(bitrand(rng_instance, D))
 end
 
 function BinaryHV(
-    this::Any;
-    D::Integer=10_000
-)
+        this::Any;
+        D::Integer = 10_000
+    )
     warn_integer_token(BinaryHV, this)
     rng_instance = Xoshiro(hash(this))
     return BinaryHV(bitrand(rng_instance, D))
@@ -526,32 +526,32 @@ julia> RealHV(; D = 8, distr = Normal(0, 5), rng = Xoshiro(1))
 
 [`AbstractHV`](@ref), [`bundle`](@ref), [`bind`](@ref), [`similarity`](@ref)
 """
-struct RealHV{T<:Real} <: AbstractHV{T}
+struct RealHV{T <: Real} <: AbstractHV{T}
     v::Vector{T}
     distr::Distribution
 
     RealHV(
         v::AbstractVector{T},
-        distr::Distribution=eldist(RealHV)
-    ) where {T<:Real} = new{T}(v, distr)
+        distr::Distribution = eldist(RealHV)
+    ) where {T <: Real} = new{T}(v, distr)
 end
 
 # Constructors
 function RealHV(;
-    distr::Distribution=eldist(RealHV),
-    D::Integer=10_000,
-    seed::Union{Integer,Nothing}=nothing,
-    rng::AbstractRNG=Random.default_rng()
-)
+        distr::Distribution = eldist(RealHV),
+        D::Integer = 10_000,
+        seed::Union{Integer, Nothing} = nothing,
+        rng::AbstractRNG = Random.default_rng()
+    )
     rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return RealHV(rand(rng_instance, distr, D), distr)
 end
 
 function RealHV(
-    this::Any;
-    D::Integer=10_000,
-    distr::Distribution=eldist(RealHV)
-)
+        this::Any;
+        D::Integer = 10_000,
+        distr::Distribution = eldist(RealHV)
+    )
     warn_integer_token(RealHV, this)
     rng_instance = Xoshiro(hash(this))
     return RealHV(rand(rng_instance, distr, D), distr)
@@ -559,7 +559,7 @@ end
 
 # Helpers
 Base.copy(hv::RealHV) = RealHV(copy(hv.v), hv.distr)
-Base.similar(hv::RealHV) = RealHV(; D=length(hv), distr=hv.distr)
+Base.similar(hv::RealHV) = RealHV(; D = length(hv), distr = hv.distr)
 function normalize!(hv::RealHV)
     hv.v .*= std(hv.distr) / std(hv.v)
     return hv
@@ -622,33 +622,33 @@ julia> GradedHV([1.0, 0.0, 0.5]) * GradedHV([1.0, 1.0, 1.0])
 
 [`AbstractHV`](@ref), [`GradedBipolarHV`](@ref), [`bundle`](@ref), [`bind`](@ref), [`similarity`](@ref)
 """
-struct GradedHV{T<:Real} <: AbstractHV{T}
+struct GradedHV{T <: Real} <: AbstractHV{T}
     v::Vector{T}
     distr::Distribution
 
     GradedHV(
         v::AbstractVector{T},
-        distr::Distribution=eldist(GradedHV)
-    ) where {T<:Real} = new{T}(clamp.(v, 0, 1), distr)
+        distr::Distribution = eldist(GradedHV)
+    ) where {T <: Real} = new{T}(clamp.(v, 0, 1), distr)
 end
 
 # Constructors
 function GradedHV(;
-    D::Integer=10_000,
-    distr::Distribution=eldist(GradedHV),
-    seed::Union{Integer,Nothing}=nothing,
-    rng::AbstractRNG=Random.default_rng()
-)
+        D::Integer = 10_000,
+        distr::Distribution = eldist(GradedHV),
+        seed::Union{Integer, Nothing} = nothing,
+        rng::AbstractRNG = Random.default_rng()
+    )
     @assert 0 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [0,1]"
     rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return GradedHV(rand(rng_instance, distr, D), distr)
 end
 
 function GradedHV(
-    this::Any;
-    D::Integer=10_000,
-    distr::Distribution=eldist(GradedHV)
-)
+        this::Any;
+        D::Integer = 10_000,
+        distr::Distribution = eldist(GradedHV)
+    )
     @assert 0 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [0,1]"
     warn_integer_token(GradedHV, this)
     rng_instance = Xoshiro(hash(this))
@@ -657,7 +657,7 @@ end
 
 # Helpers
 Base.copy(hv::GradedHV) = GradedHV(copy(hv.v), hv.distr)
-Base.similar(hv::GradedHV) = GradedHV(; D=length(hv), distr=hv.distr)
+Base.similar(hv::GradedHV) = GradedHV(; D = length(hv), distr = hv.distr)
 Base.zeros(hv::GradedHV) = fill!(similar(hv.v), one(eltype(hv.v)) / 2)
 normalize!(hv::GradedHV) = (clamp!(hv.v, 0, 1); hv)
 eldist(::Type{<:GradedHV}) = Beta(1, 1)
@@ -720,32 +720,32 @@ julia> GradedBipolarHV([-1.0, 0.0, 1.0]) * GradedBipolarHV([1.0, 1.0, 1.0])
 
 [`AbstractHV`](@ref), [`GradedHV`](@ref), [`bundle`](@ref), [`bind`](@ref), [`similarity`](@ref)
 """
-struct GradedBipolarHV{T<:Real} <: AbstractHV{T}
+struct GradedBipolarHV{T <: Real} <: AbstractHV{T}
     v::Vector{T}
     distr::Distribution
 
     GradedBipolarHV(
         v::AbstractVector{T},
-        distr::Distribution=eldist(GradedBipolarHV)
-    ) where {T<:Real} = new{T}(clamp.(v, -1, 1), distr)
+        distr::Distribution = eldist(GradedBipolarHV)
+    ) where {T <: Real} = new{T}(clamp.(v, -1, 1), distr)
 end
 
 function GradedBipolarHV(;
-    D::Integer=10_000,
-    distr::Distribution=eldist(GradedBipolarHV),
-    seed::Union{Integer,Nothing}=nothing,
-    rng::AbstractRNG=Random.default_rng()
-)
+        D::Integer = 10_000,
+        distr::Distribution = eldist(GradedBipolarHV),
+        seed::Union{Integer, Nothing} = nothing,
+        rng::AbstractRNG = Random.default_rng()
+    )
     @assert -1 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [-1,1]"
     rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return GradedBipolarHV(rand(rng_instance, distr, D), distr)
 end
 
 function GradedBipolarHV(
-    this::Any;
-    D::Integer=10_000,
-    distr::Distribution=eldist(GradedBipolarHV)
-)
+        this::Any;
+        D::Integer = 10_000,
+        distr::Distribution = eldist(GradedBipolarHV)
+    )
     @assert -1 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [-1,1]"
     warn_integer_token(GradedBipolarHV, this)
     rng_instance = Xoshiro(hash(this))
@@ -754,7 +754,7 @@ end
 
 # Helpers
 Base.copy(hv::GradedBipolarHV) = GradedBipolarHV(copy(hv.v), hv.distr)
-Base.similar(hv::GradedBipolarHV) = GradedBipolarHV(; D=length(hv), distr=hv.distr)
+Base.similar(hv::GradedBipolarHV) = GradedBipolarHV(; D = length(hv), distr = hv.distr)
 normalize!(hv::GradedBipolarHV) = (clamp!(hv.v, -1, 1); hv)
 eldist(::Type{<:GradedBipolarHV}) = 2Beta(1, 1) - 1
 
@@ -817,23 +817,23 @@ true
 
 - Plate, T. A. (1995). Holographic Reduced Representations. IEEE Transactions on Neural Networks, 6(3), 623–641.
 """
-struct FHRR{T<:Complex} <: AbstractHV{T}
+struct FHRR{T <: Complex} <: AbstractHV{T}
     v::Vector{T}
 end
 
 function FHRR(;
-    D::Integer=10_000,
-    T::Type=Float64,
-    seed::Union{Integer,Nothing}=nothing,
-    rng::AbstractRNG=Random.default_rng()
-)
+        D::Integer = 10_000,
+        T::Type = Float64,
+        seed::Union{Integer, Nothing} = nothing,
+        rng::AbstractRNG = Random.default_rng()
+    )
     rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return FHRR(exp.(2π * im .* rand(rng_instance, T, D)))
 end
 
-function FHRR(this::Any; D::Integer=10_000, T::Type=Float64)
+function FHRR(this::Any; D::Integer = 10_000, T::Type = Float64)
     warn_integer_token(FHRR, this)
-    return FHRR(; T=T, D=D, seed=hash(this))
+    return FHRR(; T = T, D = D, seed = hash(this))
 end
 
 Base.similar(hv::FHRR{<:Complex{R}}) where {R} = FHRR(exp.(2π * im .* rand(R, length(hv))))

--- a/src/types.jl
+++ b/src/types.jl
@@ -21,24 +21,155 @@ TODO:
 =#
 
 # ----------------------------------------------------------------------------------- AbstractHV
+"""
+    AbstractHV{T} <: AbstractVector{T}
+
+Abstract supertype of all hypervector types: [`BinaryHV`](@ref), [`BipolarHV`](@ref),
+[`TernaryHV`](@ref), [`RealHV`](@ref), [`GradedHV`](@ref), [`GradedBipolarHV`](@ref)
+and [`FHRR`](@ref).
+
+A hypervector is a high-dimensional vector (10,000 dimensions by default) that
+carries information holographically: meaning is distributed over the whole vector
+rather than located in individual elements. Hypervectors are composed with
+[`bundle`](@ref) (`+`), [`bind`](@ref) (`*`) and `shift` (`ρ`), and compared with
+[`similarity`](@ref).
+
+# Constructor convention
+
+All concrete hypervector types `HV <: AbstractHV` share the same constructor interface:
+
+    HV(; D = 10_000, seed = nothing, rng = <<<DECIDE>>>)
+    HV(this; D = 10_000, rng = <<<DECIDE>>>)
+    HV(v::AbstractVector)
+
+- `HV()` creates a fresh random hypervector. The dimensionality is set with the
+  keyword `D` (default 10,000); pass an integer `seed` for reproducibility.
+- `HV(this)` creates the *deterministic* hypervector encoding the object `this`,
+  seeded by `hash(this)`. Any token — a `Symbol`, `String`, `Char`, number, etc. —
+  gets its own reproducible, quasi-orthogonal hypervector.
+- `HV(v::AbstractVector)` wraps existing data in a hypervector.
+
+!!! warning
+    The positional argument is **always the object to encode, never a dimension**.
+    `BinaryHV(6)` is the 10,000-dimensional hypervector encoding the number `6`;
+    to set the dimensionality, use the keyword: `BinaryHV(; D = 6)`. To guard
+    against this mix-up, encoding an `Integer` emits a one-time warning per session.
+
+Some types extend this interface with type-specific keywords, e.g. `distr` for
+[`RealHV`](@ref), [`GradedHV`](@ref) and [`GradedBipolarHV`](@ref).
+
+# Examples
+
+```jldoctest
+julia> BinaryHV(:cat) == BinaryHV(:cat)   # encoding the same object twice
+true
+
+julia> BinaryHV(:cat) == BinaryHV(:dog)   # different objects, different vectors
+false
+
+julia> length(BinaryHV(:cat; D = 100))    # dimensionality is set with the keyword D
+100
+```
+
+# See also
+
+[`bundle`](@ref), [`bind`](@ref), [`similarity`](@ref)
+
+# Extended help
+
+## References
+
+- Kanerva, P. (2009). Hyperdimensional Computing: An Introduction to Computing in Distributed Representation with High-Dimensional Random Vectors. Cognitive Computation, 1(2), 139–159.
+"""
 abstract type AbstractHV{T} <: AbstractVector{T} end
 
-Base.copy(hv::HV) where {HV <: AbstractHV} = HV(copy(hv.v))
+Base.copy(hv::HV) where {HV<:AbstractHV} = HV(copy(hv.v))
 Base.getindex(hv::AbstractHV, i) = hv.v[i]
 Base.hash(hv::AbstractHV) = hash(hv.v)
-Base.similar(hv::HV) where {HV <: AbstractHV} = HV(; D = length(hv))
+Base.similar(hv::HV) where {HV<:AbstractHV} = HV(; D=length(hv))
 Base.size(hv::AbstractHV) = size(hv.v)
 Base.sum(hv::AbstractHV) = sum(hv.v)
 
 LinearAlgebra.norm(hv::AbstractHV) = norm(hv.v)
 normalize!(hv::AbstractHV) = hv
-normalize(hv::AbstractHV) = (c = copy(hv); normalize!(c); c)
+normalize(hv::AbstractHV) = (c=copy(hv); normalize!(c); c)
 
 eldist(hv::AbstractHV) = eldist(typeof(hv))
 empty_vector(hv::AbstractHV) = zero(hv.v)
 
+# The positional constructor argument is the object to encode, never a dimension.
+# Integers are the common mix-up (`BinaryHV(6)` is not 6-dimensional), so the token
+# constructors emit a one-time warning for them; Bools are exempt.
+warn_integer_token(HV::Type, this) = nothing
+warn_integer_token(HV::Type, this::Bool) = nothing
+function warn_integer_token(HV::Type, this::Integer)
+    @warn "`$HV($this)` encodes the *object* `$this` as a hypervector — the positional " *
+        "argument is never the dimensionality. Use `$HV(; D = $this)` to set the number " *
+        "of dimensions instead. (This warning is only shown once per session.)" maxlog = 1 _id = :hv_integer_token
+    return nothing
+end
+
 
 # ------------------------------------------------------------------------------------ BipolarHV
+"""
+    BipolarHV(; D = 10_000, seed = nothing, rng = <<<DECIDE>>>)
+    BipolarHV(this; D = 10_000, rng = <<<DECIDE>>>)
+    BipolarHV(v::AbstractVector{Bool})
+    BipolarHV(v::AbstractVector{<:Integer})
+
+A bipolar hypervector in the style of the Multiply-Add-Permute (MAP) vector symbolic
+architecture (Gayler, 1998). Elements are `<<<DECIDE: {-1, +1} or ±1>>>`, stored
+compactly as a `BitVector`; indexing returns `±1`. Constructing from an integer
+vector maps positive entries to `+1` and the rest to `-1`.
+
+Under this architecture, `bind` is elementwise XOR of the stored bits and
+self-inverse (binding by the same hypervector twice undoes it; note that in the
+`±1` representation this is the *negated* elementwise product), `bundle` is a
+majority vote across inputs with deterministic tie-breaking, and `similarity`
+defaults to cosine.
+
+The positional argument `this` is always the **object to encode** — it is hashed to
+seed the vector — and is *never* a dimension. Set dimensionality with the keyword
+`D`. Encoding the same object twice yields the same hypervector. See
+[`AbstractHV`](@ref) for the full convention.
+
+# Examples
+
+```jldoctest
+julia> BipolarHV(; D = 8, seed = 42, rng = Xoshiro)
+8-element BipolarHV with 3 positives and 5 negatives:
+ -1
+ -1
+ -1
+ -1
+  1
+  1
+  1
+ -1
+
+julia> BipolarHV("apple") == BipolarHV("apple")   # deterministic from hash
+true
+```
+
+Random hypervectors are quasi-orthogonal at the default `D = 10_000`:
+
+```jldoctest
+julia> x = BipolarHV(; seed = 1, rng = Xoshiro); y = BipolarHV(; seed = 2, rng = Xoshiro);
+
+julia> similarity(x, y)
+-0.0028
+```
+
+# See also
+
+[`AbstractHV`](@ref), [`bundle`](@ref), [`bind`](@ref), [`similarity`](@ref)
+
+# Extended help
+
+## References
+
+- Gayler, R. W. (1998). Multiplicative Binding, Representation Operators & Analogy. In Advances in Analogy Research: Integration of Theory and Data from the Cognitive, Computational, and Neural Sciences, 1–4.
+"""
 struct BipolarHV <: AbstractHV{Int}
     v::BitVector
     BipolarHV(v::AbstractVector{Bool}) = new(v)
@@ -46,19 +177,20 @@ end
 
 # Outer constructors
 function BipolarHV(;
-        D::Integer = 10_000,
-        seed::Union{Integer, Nothing} = nothing,
-        rng = MersenneTwister
-    )
+    D::Integer=10_000,
+    seed::Union{Integer,Nothing}=nothing,
+    rng=MersenneTwister
+)
     rng_instance = isnothing(seed) ? rng() : rng(seed)
     return BipolarHV(bitrand(rng_instance, D))
 end
 
 function BipolarHV(
-        this::Any;
-        D::Integer = 10_000,
-        rng = MersenneTwister
-    )
+    this::Any;
+    D::Integer=10_000,
+    rng=MersenneTwister
+)
+    warn_integer_token(BipolarHV, this)
     rng_instance = rng(hash(this))
     return BipolarHV(bitrand(rng_instance, D))
 end
@@ -75,90 +207,197 @@ eldist(::Type{BipolarHV}) = 2Bernoulli(0.5) - 1
 
 # ------------------------------------------------------------------------------------ TernaryHV
 """
-    TernaryHV
+    TernaryHV(; D = 10_000, seed = nothing, rng = <<<DECIDE>>>)
+    TernaryHV(this; D = 10_000, rng = <<<DECIDE>>>)
+    TernaryHV(v::AbstractVector{<:Integer})
+    TernaryHV{T}(...)
 
-A ternary hypervector type based on the Multiply-Add-Permute (MAP) vector symbolic architecture
-(Gayler, 1998).
+A ternary hypervector implementing the Multiply-Add-Permute (MAP) vector symbolic
+architecture (Gayler, 1998). Elements are integers, stored as a `Vector{T}` with
+`T <: Integer`; the random constructors generate only `±1` entries, and zeros arise
+from operations such as unnormalized bundling. All constructor forms also exist with
+an explicit element type, `TernaryHV{T}(...)`.
 
-Represents a hypervector with elements in `{-1, +1}`.
+Under MAP, `bind` is elementwise multiplication and self-inverse, `bundle` is
+elementwise addition *without* normalization by default (so counts accumulate;
+`normalize` clamps the result back to `{-1, 0, +1}`), and `similarity` defaults to
+cosine.
+
+The positional argument `this` is always the **object to encode** — it is hashed to
+seed the vector — and is *never* a dimension. Set dimensionality with the keyword
+`D`. Encoding the same object twice yields the same hypervector. See
+[`AbstractHV`](@ref) for the full convention.
+
+# Examples
+
+```jldoctest
+julia> TernaryHV(; D = 8, seed = 42, rng = Xoshiro)
+8-element TernaryHV{Int64} with μ ± σ = 0.0 ± 1.069:
+  1
+  1
+ -1
+ -1
+ -1
+ -1
+  1
+  1
+
+julia> TernaryHV("apple") == TernaryHV("apple")   # deterministic from hash
+true
+```
+
+Bundling accumulates counts; `normalize` clamps back to `{-1, 0, +1}`:
+
+```jldoctest
+julia> x = TernaryHV(; D = 8, seed = 1, rng = Xoshiro); y = TernaryHV(; D = 8, seed = 2, rng = Xoshiro);
+
+julia> x + y
+8-element TernaryHV{Int64} with μ ± σ = 0.0 ± 1.852:
+ -2
+  0
+ -2
+ -2
+  0
+  2
+  2
+  2
+
+julia> normalize(x + y)
+8-element TernaryHV{Int64} with μ ± σ = 0.0 ± 0.926:
+ -1
+  0
+ -1
+ -1
+  0
+  1
+  1
+  1
+```
+
+# See also
+
+[`AbstractHV`](@ref), [`bundle`](@ref), [`bind`](@ref), [`similarity`](@ref)
 
 # Extended help
 
 ## References
 
-- Gayler, R. W. (1998). Multiplicative Binding, Representation Operators & Analogy. In Advances in Analogy Research: Integration of Theory and Data from the Cognitive, Computational, and Neural Sciences, pages 1–4.
+- Gayler, R. W. (1998). Multiplicative Binding, Representation Operators & Analogy. In Advances in Analogy Research: Integration of Theory and Data from the Cognitive, Computational, and Neural Sciences, 1–4.
 """
-struct TernaryHV{T <: Integer} <: AbstractHV{T}
+struct TernaryHV{T<:Integer} <: AbstractHV{T}
     v::Vector{T}
 
     # Inner constructor for same type
-    TernaryHV{T}(v::AbstractVector{T}) where {T <: Integer} = new{T}(v)
+    TernaryHV{T}(v::AbstractVector{T}) where {T<:Integer} = new{T}(v)
     # Inner constructor for type conversion
-    TernaryHV{T}(v::AbstractVector{<:Integer}) where {T <: Integer} = new{T}(convert(Vector{T}, v))
+    TernaryHV{T}(v::AbstractVector{<:Integer}) where {T<:Integer} = new{T}(convert(Vector{T}, v))
 end
 
 # Outer constructor that infers type from input
-TernaryHV(v::AbstractVector{T}) where {T <: Integer} = TernaryHV{T}(v)
+TernaryHV(v::AbstractVector{T}) where {T<:Integer} = TernaryHV{T}(v)
 
 function TernaryHV(;
-        D::Integer = 10_000,
-        seed::Union{Integer, Nothing} = nothing,
-        rng = Random.MersenneTwister
-    )
+    D::Integer=10_000,
+    seed::Union{Integer,Nothing}=nothing,
+    rng=Random.MersenneTwister
+)
     rng_instance = isnothing(seed) ? rng() : rng(seed)
     return TernaryHV{Int}(rand(rng_instance, (-1, 1), D))
 end
 
 function TernaryHV(
-        this::Any;
-        D::Integer = 10_000,
-        rng = Random.MersenneTwister
-    )
+    this::Any;
+    D::Integer=10_000,
+    rng=Random.MersenneTwister
+)
+    warn_integer_token(TernaryHV, this)
     rng_instance = rng(hash(this))
     return TernaryHV{Int}(rand(rng_instance, (-1, 1), D))
 end
 
 function TernaryHV{T}(;
-        D::Integer = 10_000,
-        seed::Union{Integer, Nothing} = nothing,
-        rng = Random.MersenneTwister
-    ) where {T <: Integer}
+    D::Integer=10_000,
+    seed::Union{Integer,Nothing}=nothing,
+    rng=Random.MersenneTwister
+) where {T<:Integer}
     rng_instance = isnothing(seed) ? rng() : rng(seed)
     return TernaryHV{T}(convert(Vector{T}, rand(rng_instance, (-1, 1), D)))
 end
 
 function TernaryHV{T}(
-        this::Any;
-        D::Integer = 10_000,
-        rng = Random.MersenneTwister
-    ) where {T <: Integer}
+    this::Any;
+    D::Integer=10_000,
+    rng=Random.MersenneTwister
+) where {T<:Integer}
+    warn_integer_token(TernaryHV{T}, this)
     rng_instance = rng(hash(this))
     return TernaryHV{T}(convert(Vector{T}, rand(rng_instance, (-1, 1), D)))
 end
 
 # Helpers
 Base.copy(hv::TernaryHV{T}) where {T} = TernaryHV{T}(copy(hv.v))
-Base.similar(hv::TernaryHV{T}) where {T} = TernaryHV{T}(; D = length(hv))
+Base.similar(hv::TernaryHV{T}) where {T} = TernaryHV{T}(; D=length(hv))
 normalize!(hv::TernaryHV) = clamp!(hv.v, -1, 1)
 eldist(::Type{<:TernaryHV}) = 2Bernoulli(0.5) - 1
 
 # ------------------------------------------------------------------------------------ BinaryHV
 """
-    BinaryHV
+    BinaryHV(; D = 10_000, seed = nothing, rng = <<<DECIDE>>>)
+    BinaryHV(this; D = 10_000, rng = <<<DECIDE>>>)
+    BinaryHV(v::AbstractVector{Bool})
 
-A binary hypervector type based on the Binary Spatter Code (BSC) vector symbolic architecture
-(Kanerva, 1994; Kanerva, 1995; Kanerva, 1996; Kanerva, 1997).
+A binary hypervector implementing the Binary Spatter Code (BSC) vector symbolic
+architecture (Kanerva, 1994–1997). Elements are `<<<DECIDE: {0,1} or {false,true}>>>`,
+stored compactly as a `BitVector`.
 
-Represents a hypervector boolean elements, i.e. `(false, true)`.
+Under BSC, `bind` is elementwise XOR and self-inverse (binding by the same
+hypervector twice undoes it), `bundle` is a majority vote across inputs with
+deterministic tie-breaking, and `similarity` defaults to Jaccard.
+
+The positional argument `this` is always the **object to encode** — it is hashed to
+seed the vector — and is *never* a dimension. Set dimensionality with the keyword
+`D`. Encoding the same object twice yields the same hypervector. See
+[`AbstractHV`](@ref) for the full convention.
+
+# Examples
+
+```jldoctest
+julia> BinaryHV(; D = 8, seed = 42, rng = Xoshiro)
+8-element BinaryHV with 3 true and 5 false:
+ 0
+ 0
+ 0
+ 0
+ 1
+ 1
+ 1
+ 0
+
+julia> BinaryHV("apple") == BinaryHV("apple")   # deterministic from hash
+true
+```
+
+Binding is self-inverse:
+
+```jldoctest
+julia> x = BinaryHV(; D = 8, seed = 1, rng = Xoshiro); y = BinaryHV(; D = 8, seed = 2, rng = Xoshiro);
+
+julia> x * y * y == x
+true
+```
+
+# See also
+
+[`AbstractHV`](@ref), [`bundle`](@ref), [`bind`](@ref), [`similarity`](@ref)
 
 # Extended help
 
 ## References
 
-- Kanerva, P. (1994). The Spatter Code for Encoding Concepts at Many Levels. In International Conference on Artificial Neural Networks (ICANN), pages 226–229.
-- Kanerva, P. (1995). A Family of Binary Spatter Codes. In International Conference on Artificial Neural Networks (ICANN), pages 517–522.
-- Kanerva, P. (1996). Binary Spatter-Coding of Ordered K-tuples. In International Conference on Artificial Neural Networks (ICANN), volume 1112 of Lecture Notes in Computer Science, pages 869–873.
-- Kanerva, P. (1997). Fully Distributed Representation. In Real World Computing Symposium (RWC), pages 358–365.
+- Kanerva, P. (1994). The Spatter Code for Encoding Concepts at Many Levels. ICANN, 226–229.
+- Kanerva, P. (1995). A Family of Binary Spatter Codes. ICANN, 517–522.
+- Kanerva, P. (1996). Binary Spatter-Coding of Ordered K-tuples. ICANN, LNCS 1112, 869–873.
+- Kanerva, P. (1997). Fully Distributed Representation. RWC, 358–365.
 """
 struct BinaryHV <: AbstractHV{Bool}
     v::BitVector
@@ -167,19 +406,20 @@ struct BinaryHV <: AbstractHV{Bool}
 end
 
 function BinaryHV(;
-        D::Integer = 10_000,
-        seed::Union{Integer, Nothing} = nothing,
-        rng = Random.MersenneTwister
-    )
+    D::Integer=10_000,
+    seed::Union{Integer,Nothing}=nothing,
+    rng=Random.MersenneTwister
+)
     rng_instance = isnothing(seed) ? rng() : rng(seed)
     return BinaryHV(bitrand(rng_instance, D))
 end
 
 function BinaryHV(
-        this::Any;
-        D::Integer = 10_000,
-        rng = Random.MersenneTwister
-    )
+    this::Any;
+    D::Integer=10_000,
+    rng=Random.MersenneTwister
+)
+    warn_integer_token(BinaryHV, this)
     rng_instance = rng(hash(this))
     return BinaryHV(bitrand(rng_instance, D))
 end
@@ -190,40 +430,97 @@ eldist(::Type{BinaryHV}) = Bernoulli(0.5)
 
 
 # --------------------------------------------------------------------------------------- RealHV
-struct RealHV{T <: Real} <: AbstractHV{T}
+"""
+    RealHV(; D = 10_000, distr = Normal(), seed = nothing, rng = <<<DECIDE>>>)
+    RealHV(this; D = 10_000, distr = Normal(), rng = <<<DECIDE>>>)
+    RealHV(v::AbstractVector{<:Real}[, distr])
+
+A real-valued hypervector (continuous Multiply-Add-Permute architecture). Elements
+are drawn from a configurable distribution `distr` (standard normal by default),
+which the vector carries along so that `normalize!` can rescale a result back to
+the original spread.
+
+Under this architecture, `bind` is elementwise multiplication, inverted exactly by
+[`unbind`](@ref) (elementwise division), `bundle` is elementwise addition rescaled
+by `√m` for `m` inputs, and `similarity` defaults to cosine.
+
+The positional argument `this` is always the **object to encode** — it is hashed to
+seed the vector — and is *never* a dimension. Set dimensionality with the keyword
+`D`. Encoding the same object twice yields the same hypervector. See
+[`AbstractHV`](@ref) for the full convention.
+
+# Examples
+
+```jldoctest
+julia> RealHV(; D = 8, seed = 42, rng = Xoshiro)
+8-element RealHV{Float64} with μ ± σ = -0.222 ± 0.736:
+ -0.36335748145177754
+  0.2517372155742292
+ -0.31498797116895605
+ -0.31125240132442067
+  0.8163067649323273
+  0.47673837983187795
+ -0.8595553820616212
+ -1.4692882055065464
+
+julia> RealHV("apple") == RealHV("apple")   # deterministic from hash
+true
+```
+
+The `distr` keyword controls the element distribution:
+
+```jldoctest
+julia> RealHV(; D = 8, distr = Normal(0, 5), seed = 1, rng = Xoshiro)
+8-element RealHV{Float64} with μ ± σ = 0.214 ± 4.17:
+  0.30966370157040063
+  1.392029070820001
+ -2.9791220768202606
+  0.2332969478669087
+  5.428970107716381
+ -7.88282461292992
+  0.8796999565053736
+  4.326904027046626
+```
+
+# See also
+
+[`AbstractHV`](@ref), [`bundle`](@ref), [`bind`](@ref), [`similarity`](@ref)
+"""
+struct RealHV{T<:Real} <: AbstractHV{T}
     v::Vector{T}
     distr::Distribution
 
     RealHV(
         v::AbstractVector{T},
-        distr::Distribution = eldist(RealHV)
-    ) where {T <: Real} = new{T}(v, distr)
+        distr::Distribution=eldist(RealHV)
+    ) where {T<:Real} = new{T}(v, distr)
 end
 
 # Constructors
 function RealHV(;
-        distr::Distribution = eldist(RealHV),
-        D::Integer = 10_000,
-        seed::Union{Integer, Nothing} = nothing,
-        rng = Random.MersenneTwister
-    )
+    distr::Distribution=eldist(RealHV),
+    D::Integer=10_000,
+    seed::Union{Integer,Nothing}=nothing,
+    rng=Random.MersenneTwister
+)
     rng_instance = isnothing(seed) ? rng() : rng(seed)
     return RealHV(rand(rng_instance, distr, D), distr)
 end
 
 function RealHV(
-        this::Any;
-        D::Integer = 10_000,
-        distr::Distribution = eldist(RealHV),
-        rng = Random.MersenneTwister
-    )
+    this::Any;
+    D::Integer=10_000,
+    distr::Distribution=eldist(RealHV),
+    rng=Random.MersenneTwister
+)
+    warn_integer_token(RealHV, this)
     rng_instance = rng(hash(this))
     return RealHV(rand(rng_instance, distr, D), distr)
 end
 
 # Helpers
 Base.copy(hv::RealHV) = RealHV(copy(hv.v), hv.distr)
-Base.similar(hv::RealHV) = RealHV(; D = length(hv), distr = hv.distr)
+Base.similar(hv::RealHV) = RealHV(; D=length(hv), distr=hv.distr)
 function normalize!(hv::RealHV)
     hv.v .*= std(hv.distr) / std(hv.v)
     return hv
@@ -232,42 +529,94 @@ eldist(::Type{<:RealHV}) = Normal()
 
 
 # -------------------------------------------------------------------------------------- GradedHV
-struct GradedHV{T <: Real} <: AbstractHV{T}
+"""
+    GradedHV(; D = 10_000, distr = Beta(1, 1), seed = nothing, rng = <<<DECIDE>>>)
+    GradedHV(this; D = 10_000, distr = Beta(1, 1), rng = <<<DECIDE>>>)
+    GradedHV(v::AbstractVector{<:Real}[, distr])
+
+A graded hypervector with elements in the fuzzy-membership interval `[0, 1]`.
+Elements are drawn from a distribution with support in `[0, 1]` (uniform
+`Beta(1, 1)` by default, via the `distr` keyword); values passed as data are
+clamped to `[0, 1]`.
+
+Operations follow fuzzy logic: `bind` is the fuzzy XOR
+`(1 - x) * y + x * (1 - y)`, `bundle` uses the three-valued π aggregation, and
+`similarity` defaults to Jaccard.
+
+The positional argument `this` is always the **object to encode** — it is hashed to
+seed the vector — and is *never* a dimension. Set dimensionality with the keyword
+`D`. Encoding the same object twice yields the same hypervector. See
+[`AbstractHV`](@ref) for the full convention.
+
+# Examples
+
+```jldoctest
+julia> GradedHV(; D = 8, seed = 42, rng = Xoshiro)
+8-element GradedHV{Float64} with μ ± σ = 0.532 ± 0.247:
+ 0.8023279156644033
+ 0.6042216741680727
+ 0.5612409791764235
+ 0.8514212832811604
+ 0.5873457677614401
+ 0.4663593857124599
+ 0.13521235508492413
+ 0.24655411787892703
+
+julia> GradedHV("apple") == GradedHV("apple")   # deterministic from hash
+true
+```
+
+Binding is fuzzy XOR, so binding with certainty (`1.0`) negates the membership:
+
+```jldoctest
+julia> GradedHV([1.0, 0.0, 0.5]) * GradedHV([1.0, 1.0, 1.0])
+3-element GradedHV{Float64} with μ ± σ = 0.5 ± 0.5:
+ 0.0
+ 1.0
+ 0.5
+```
+
+# See also
+
+[`AbstractHV`](@ref), [`GradedBipolarHV`](@ref), [`bundle`](@ref), [`bind`](@ref), [`similarity`](@ref)
+"""
+struct GradedHV{T<:Real} <: AbstractHV{T}
     v::Vector{T}
     distr::Distribution
 
     GradedHV(
         v::AbstractVector{T},
-        distr::Distribution = eldist(GradedHV)
-    ) where {T <: Real} = new{T}(clamp.(v, 0, 1), distr)
+        distr::Distribution=eldist(GradedHV)
+    ) where {T<:Real} = new{T}(clamp.(v, 0, 1), distr)
 end
 
 # Constructors
 function GradedHV(;
-        D::Integer = 10_000,
-        distr::Distribution = eldist(GradedHV),
-        seed::Union{Integer, Nothing} = nothing,
-        rng = Random.MersenneTwister
-    )
+    D::Integer=10_000,
+    distr::Distribution=eldist(GradedHV),
+    seed::Union{Integer,Nothing}=nothing,
+    rng=Random.MersenneTwister
+)
     @assert 0 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [0,1]"
     rng_instance = isnothing(seed) ? rng() : rng(seed)
     return GradedHV(rand(rng_instance, distr, D), distr)
 end
 
 function GradedHV(
-        this::Any;
-        D::Integer = 10_000,
-        distr::Distribution = eldist(GradedHV),
-        rng = Random.MersenneTwister
-    )
+    this::Any;
+    D::Integer=10_000,
+    distr::Distribution=eldist(GradedHV),
+    rng=Random.MersenneTwister
+)
     @assert 0 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [0,1]"
+    warn_integer_token(GradedHV, this)
     rng_instance = rng(hash(this))
     return GradedHV(rand(rng_instance, distr, D), distr)
 end
 
 # Helpers
 Base.copy(hv::GradedHV) = GradedHV(copy(hv.v), hv.distr)
-Base.similar(hv::GradedHV) = GradedHV(; D = length(hv), distr = hv.distr)
+Base.similar(hv::GradedHV) = GradedHV(; D=length(hv), distr=hv.distr)
 Base.zeros(hv::GradedHV) = fill!(similar(hv.v), one(eltype(hv.v)) / 2)
 normalize!(hv::GradedHV) = clamp!(hv.v, 0, 1)
 eldist(::Type{<:GradedHV}) = Beta(1, 1)
@@ -275,63 +624,170 @@ empty_vector(hv::GradedHV) = fill!(zero(hv.v), 0.5)
 
 
 # -------------------------------------------------------------------------------- GradedBipolarHV
-struct GradedBipolarHV{T <: Real} <: AbstractHV{T}
+"""
+    GradedBipolarHV(; D = 10_000, distr = 2Beta(1, 1) - 1, seed = nothing, rng = <<<DECIDE>>>)
+    GradedBipolarHV(this; D = 10_000, distr = 2Beta(1, 1) - 1, rng = <<<DECIDE>>>)
+    GradedBipolarHV(v::AbstractVector{<:Real}[, distr])
+
+A graded bipolar hypervector with elements in `[-1, 1]`, the bipolar counterpart of
+[`GradedHV`](@ref). Elements are drawn from a distribution with support in `[-1, 1]`
+(the scaled uniform `2Beta(1, 1) - 1` by default, via the `distr` keyword); values
+passed as data are clamped to `[-1, 1]`.
+
+Operations are the fuzzy-logic operations of [`GradedHV`](@ref) mapped to the
+bipolar interval: `bind` is fuzzy XOR and `bundle` the three-valued π aggregation,
+both applied after rescaling `[-1, 1]` to `[0, 1]` and mapping back; `similarity`
+defaults to cosine.
+
+The positional argument `this` is always the **object to encode** — it is hashed to
+seed the vector — and is *never* a dimension. Set dimensionality with the keyword
+`D`. Encoding the same object twice yields the same hypervector. See
+[`AbstractHV`](@ref) for the full convention.
+
+# Examples
+
+```jldoctest
+julia> GradedBipolarHV(; D = 8, seed = 42, rng = Xoshiro)
+8-element GradedBipolarHV{Float64} with μ ± σ = 0.064 ± 0.494:
+  0.6046558313288066
+  0.20844334833614542
+  0.12248195835284692
+  0.7028425665623208
+  0.1746915355228802
+ -0.06728122857508023
+ -0.7295752898301517
+ -0.506891764242146
+
+julia> GradedBipolarHV("apple") == GradedBipolarHV("apple")   # deterministic from hash
+true
+```
+
+Binding with full certainty (`1.0`) mirrors a value across the interval:
+
+```jldoctest
+julia> GradedBipolarHV([-1.0, 0.0, 1.0]) * GradedBipolarHV([1.0, 1.0, 1.0])
+3-element GradedBipolarHV{Float64} with μ ± σ = 0.0 ± 1.0:
+  1.0
+  0.0
+ -1.0
+```
+
+# See also
+
+[`AbstractHV`](@ref), [`GradedHV`](@ref), [`bundle`](@ref), [`bind`](@ref), [`similarity`](@ref)
+"""
+struct GradedBipolarHV{T<:Real} <: AbstractHV{T}
     v::Vector{T}
     distr::Distribution
 
     GradedBipolarHV(
         v::AbstractVector{T},
-        distr::Distribution = eldist(GradedBipolarHV)
-    ) where {T <: Real} = new{T}(clamp.(v, -1, 1), distr)
+        distr::Distribution=eldist(GradedBipolarHV)
+    ) where {T<:Real} = new{T}(clamp.(v, -1, 1), distr)
 end
 
 function GradedBipolarHV(;
-        D::Integer = 10_000,
-        distr::Distribution = eldist(GradedBipolarHV),
-        seed::Union{Integer, Nothing} = nothing,
-        rng = Random.MersenneTwister
-    )
+    D::Integer=10_000,
+    distr::Distribution=eldist(GradedBipolarHV),
+    seed::Union{Integer,Nothing}=nothing,
+    rng=Random.MersenneTwister
+)
     @assert -1 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [-1,1]"
     rng_instance = isnothing(seed) ? rng() : rng(seed)
     return GradedBipolarHV(rand(rng_instance, distr, D), distr)
 end
 
 function GradedBipolarHV(
-        this::Any;
-        D::Integer = 10_000,
-        distr::Distribution = eldist(GradedBipolarHV),
-        rng = Random.MersenneTwister
-    )
+    this::Any;
+    D::Integer=10_000,
+    distr::Distribution=eldist(GradedBipolarHV),
+    rng=Random.MersenneTwister
+)
     @assert -1 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [-1,1]"
+    warn_integer_token(GradedBipolarHV, this)
     rng_instance = rng(hash(this))
     return GradedBipolarHV(rand(rng_instance, distr, D), distr)
 end
 
 # Helpers
 Base.copy(hv::GradedBipolarHV) = GradedBipolarHV(copy(hv.v), hv.distr)
-Base.similar(hv::GradedBipolarHV) = GradedBipolarHV(; D = length(hv), distr = hv.distr)
+Base.similar(hv::GradedBipolarHV) = GradedBipolarHV(; D=length(hv), distr=hv.distr)
 normalize!(hv::GradedBipolarHV) = clamp!(hv.v, -1, 1)
 eldist(::Type{<:GradedBipolarHV}) = 2Beta(1, 1) - 1
 
 # Fourier Holographic Reduced Representations
 # --------------------------------------------
 
-struct FHRR{T <: Complex} <: AbstractHV{T}
+"""
+    FHRR(; D = 10_000, T = Float64, seed = nothing, rng = <<<DECIDE>>>)
+    FHRR(this; D = 10_000, T = Float64, rng = <<<DECIDE>>>)
+    FHRR(v::AbstractVector{<:Complex})
+
+A Fourier Holographic Reduced Representation hypervector (Plate, 1995). Elements are
+complex numbers on the unit circle, `e^(iθ)` with random phase `θ`, stored as a
+`Vector{Complex{T}}` (`T = Float64` by default, via the `T` keyword).
+
+Under FHRR, `bind` is elementwise complex multiplication (phases add), inverted by
+[`unbind`](@ref) (elementwise division), `bundle` is phasor addition renormalized to
+unit modulus, and `similarity` is the normalized real part of the complex dot
+product. In addition, `hv ^ x` raises every phase to the power `x`, which enables
+fractional-power (level) encoding of continuous values.
+
+The positional argument `this` is always the **object to encode** — it is hashed to
+seed the vector — and is *never* a dimension. Set dimensionality with the keyword
+`D`. Encoding the same object twice yields the same hypervector. See
+[`AbstractHV`](@ref) for the full convention.
+
+# Examples
+
+```jldoctest
+julia> FHRR(; D = 4, seed = 42, rng = Xoshiro)
+4-element FHRR{ComplexF64} with μ ± σ = -0.73 - 0.309im ± 0.704:
+ -0.6875407989187119 - 0.7261457497102214im
+ -0.9517124499338168 + 0.3069908999318585im
+ -0.9899412825080958 + 0.14147882239482543im
+ -0.2902555218408553 - 0.9569491794452267im
+
+julia> FHRR("apple") == FHRR("apple")   # deterministic from hash
+true
+```
+
+Fractional powers encode continuous values: nearby exponents stay similar.
+
+```jldoctest
+julia> x = FHRR(; seed = 1, rng = Xoshiro);
+
+julia> similarity(x^1.0, x^1.05) > similarity(x^1.0, x^2.0)
+true
+```
+
+# See also
+
+[`AbstractHV`](@ref), [`bundle`](@ref), [`bind`](@ref), [`unbind`](@ref), [`similarity`](@ref)
+
+# Extended help
+
+## References
+
+- Plate, T. A. (1995). Holographic Reduced Representations. IEEE Transactions on Neural Networks, 6(3), 623–641.
+"""
+struct FHRR{T<:Complex} <: AbstractHV{T}
     v::Vector{T}
 end
 
 function FHRR(;
-        D::Integer = 10_000,
-        T::Type = Float64,
-        seed::Union{Integer, Nothing} = nothing,
-        rng = Random.MersenneTwister
-    )
+    D::Integer=10_000,
+    T::Type=Float64,
+    seed::Union{Integer,Nothing}=nothing,
+    rng=Random.MersenneTwister
+)
     rng_instance = isnothing(seed) ? rng() : rng(seed)
     return FHRR(exp.(2π * im .* rand(rng_instance, T, D)))
 end
 
-function FHRR(this::Any; D::Integer = 10_000, T::Type = Float64, rng = Random.MersenneTwister)
-    return FHRR(; T = T, D = D, seed = hash(this), rng = rng)
+function FHRR(this::Any; D::Integer=10_000, T::Type=Float64, rng=Random.MersenneTwister)
+    warn_integer_token(FHRR, this)
+    return FHRR(; T=T, D=D, seed=hash(this), rng=rng)
 end
 
 Base.similar(hv::FHRR{<:Complex{R}}) where {R} = FHRR(exp.(2π * im .* rand(R, length(hv))))

--- a/src/types.jl
+++ b/src/types.jl
@@ -58,6 +58,14 @@ All concrete hypervector types `HV <: AbstractHV` share the same constructor int
 Some types extend this interface with type-specific keywords, e.g. `distr` for
 [`RealHV`](@ref), [`GradedHV`](@ref) and [`GradedBipolarHV`](@ref).
 
+# Indexing
+
+`hv[i]` with an integer returns the element value. Non-scalar indexing —
+`hv[1:3]`, `hv[[1, 4]]`, logical masks — returns a plain `Vector` of element
+values, *not* a new hypervector: information in a hypervector is distributed over
+all `D` dimensions, so a slice is not itself a meaningful hypervector.
+Hypervectors are immutable; there is no `setindex!`.
+
 # Examples
 
 ```jldoctest
@@ -84,7 +92,11 @@ julia> length(BinaryHV(:cat; D = 100))    # dimensionality is set with the keywo
 abstract type AbstractHV{T} <: AbstractVector{T} end
 
 Base.copy(hv::HV) where {HV<:AbstractHV} = HV(copy(hv.v))
-Base.getindex(hv::AbstractHV, i) = hv.v[i]
+# Scalar indexing returns the element value; non-scalar indexing (ranges, index
+# vectors, logical masks) returns a plain Vector of element values, NOT a new
+# hypervector — a slice of a hypervector is not a meaningful hypervector.
+Base.getindex(hv::AbstractHV, i::Integer) = hv.v[i]
+Base.getindex(hv::AbstractHV, I::AbstractVector) = hv.v[I]
 Base.hash(hv::AbstractHV) = hash(hv.v)
 Base.similar(hv::HV) where {HV<:AbstractHV} = HV(; D=length(hv))
 Base.size(hv::AbstractHV) = size(hv.v)
@@ -104,8 +116,8 @@ warn_integer_token(HV::Type, this) = nothing
 warn_integer_token(HV::Type, this::Bool) = nothing
 function warn_integer_token(HV::Type, this::Integer)
     @warn "`$HV($this)` encodes the *object* `$this` as a hypervector — the positional " *
-        "argument is never the dimensionality. Use `$HV(; D = $this)` to set the number " *
-        "of dimensions instead. (This warning is only shown once per session.)" maxlog = 1 _id = :hv_integer_token
+          "argument is never the dimensionality. Use `$HV(; D = $this)` to set the number " *
+          "of dimensions instead. (This warning is only shown once per session.)" maxlog = 1 _id = :hv_integer_token
     return nothing
 end
 
@@ -118,7 +130,7 @@ end
     BipolarHV(v::AbstractVector{<:Integer})
 
 A bipolar hypervector in the style of the Multiply-Add-Permute (MAP) vector symbolic
-architecture (Gayler, 1998). Elements are `<<<DECIDE: {-1, +1} or ±1>>>`, stored
+architecture (Gayler, 1998). Elements are `±1`, stored
 compactly as a `BitVector`; indexing returns `±1`. Constructing from an integer
 vector maps positive entries to `+1` and the rest to `-1`.
 
@@ -126,7 +138,8 @@ Under this architecture, `bind` is elementwise XOR of the stored bits and
 self-inverse (binding by the same hypervector twice undoes it; note that in the
 `±1` representation this is the *negated* elementwise product), `bundle` is a
 majority vote across inputs with deterministic tie-breaking, and `similarity`
-defaults to cosine.
+defaults to cosine. Use [`TernaryHV`](@ref) for a (slightly less efficient)
+hypervector type that can contain zeros.
 
 The positional argument `this` is always the **object to encode** — it is hashed to
 seed the vector — and is *never* a dimension. Set dimensionality with the keyword
@@ -198,7 +211,8 @@ end
 BipolarHV(v::AbstractVector{<:Integer}) = BipolarHV(v .> 0)
 
 # Helpers
-Base.getindex(hv::BipolarHV, i) = hv.v[i] ? 1 : -1
+Base.getindex(hv::BipolarHV, i::Integer) = hv.v[i] ? 1 : -1
+Base.getindex(hv::BipolarHV, I::AbstractVector) = ifelse.(hv.v[I], 1, -1)
 Base.sum(hv::BipolarHV) = 2sum(hv.v) - length(hv.v)
 LinearAlgebra.norm(hv::BipolarHV) = sqrt(length(hv))
 empty_vector(hv::BipolarHV) = zeros(Int, length(hv))
@@ -232,7 +246,7 @@ seed the vector — and is *never* a dimension. Set dimensionality with the keyw
 
 ```jldoctest
 julia> TernaryHV(; D = 8, seed = 42, rng = Xoshiro)
-8-element TernaryHV{Int64} with μ ± σ = 0.0 ± 1.069:
+8-element TernaryHV{Int64} with 4 positives, 0 zeros, and 4 negatives:
   1
   1
  -1
@@ -252,7 +266,7 @@ Bundling accumulates counts; `normalize` clamps back to `{-1, 0, +1}`:
 julia> x = TernaryHV(; D = 8, seed = 1, rng = Xoshiro); y = TernaryHV(; D = 8, seed = 2, rng = Xoshiro);
 
 julia> x + y
-8-element TernaryHV{Int64} with μ ± σ = 0.0 ± 1.852:
+8-element TernaryHV{Int64} with 3 positives, 2 zeros, and 3 negatives:
  -2
   0
  -2
@@ -263,7 +277,7 @@ julia> x + y
   2
 
 julia> normalize(x + y)
-8-element TernaryHV{Int64} with μ ± σ = 0.0 ± 0.926:
+8-element TernaryHV{Int64} with 3 positives, 2 zeros, and 3 negatives:
  -1
   0
  -1

--- a/src/types.jl
+++ b/src/types.jl
@@ -38,8 +38,8 @@ rather than located in individual elements. Hypervectors are composed with
 
 All concrete hypervector types `HV <: AbstractHV` share the same constructor interface:
 
-    HV(; D = 10_000, seed = nothing, rng = <<<DECIDE>>>)
-    HV(this; D = 10_000, rng = <<<DECIDE>>>)
+    HV(; D = 10_000, seed = nothing, rng = Random.default_rng())
+    HV(this; D = 10_000)
     HV(v::AbstractVector)
 
 - `HV()` creates a fresh random hypervector. The dimensionality is set with the
@@ -124,8 +124,8 @@ end
 
 # ------------------------------------------------------------------------------------ BipolarHV
 """
-    BipolarHV(; D = 10_000, seed = nothing, rng = <<<DECIDE>>>)
-    BipolarHV(this; D = 10_000, rng = <<<DECIDE>>>)
+    BipolarHV(; D = 10_000, seed = nothing, rng = Random.default_rng())
+    BipolarHV(this; D = 10_000)
     BipolarHV(v::AbstractVector{Bool})
     BipolarHV(v::AbstractVector{<:Integer})
 
@@ -149,7 +149,7 @@ seed the vector — and is *never* a dimension. Set dimensionality with the keyw
 # Examples
 
 ```jldoctest
-julia> BipolarHV(; D = 8, seed = 42, rng = Xoshiro)
+julia> BipolarHV(; D = 8, rng = Xoshiro(42))
 8-element BipolarHV with 3 positives and 5 negatives:
  -1
  -1
@@ -167,7 +167,7 @@ true
 Random hypervectors are quasi-orthogonal at the default `D = 10_000`:
 
 ```jldoctest
-julia> x = BipolarHV(; seed = 1, rng = Xoshiro); y = BipolarHV(; seed = 2, rng = Xoshiro);
+julia> x = BipolarHV(; rng = Xoshiro(1)); y = BipolarHV(; rng = Xoshiro(2));
 
 julia> similarity(x, y)
 -0.0028
@@ -192,19 +192,18 @@ end
 function BipolarHV(;
     D::Integer=10_000,
     seed::Union{Integer,Nothing}=nothing,
-    rng=MersenneTwister
+    rng::AbstractRNG=Random.default_rng()
 )
-    rng_instance = isnothing(seed) ? rng() : rng(seed)
+    rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return BipolarHV(bitrand(rng_instance, D))
 end
 
 function BipolarHV(
     this::Any;
-    D::Integer=10_000,
-    rng=MersenneTwister
+    D::Integer=10_000
 )
     warn_integer_token(BipolarHV, this)
-    rng_instance = rng(hash(this))
+    rng_instance = Xoshiro(hash(this))
     return BipolarHV(bitrand(rng_instance, D))
 end
 
@@ -221,8 +220,8 @@ eldist(::Type{BipolarHV}) = 2Bernoulli(0.5) - 1
 
 # ------------------------------------------------------------------------------------ TernaryHV
 """
-    TernaryHV(; D = 10_000, seed = nothing, rng = <<<DECIDE>>>)
-    TernaryHV(this; D = 10_000, rng = <<<DECIDE>>>)
+    TernaryHV(; D = 10_000, seed = nothing, rng = Random.default_rng())
+    TernaryHV(this; D = 10_000)
     TernaryHV(v::AbstractVector{<:Integer})
     TernaryHV{T}(...)
 
@@ -245,7 +244,7 @@ seed the vector — and is *never* a dimension. Set dimensionality with the keyw
 # Examples
 
 ```jldoctest
-julia> TernaryHV(; D = 8, seed = 42, rng = Xoshiro)
+julia> TernaryHV(; D = 8, rng = Xoshiro(42))
 8-element TernaryHV{Int64} with 4 positives, 0 zeros, and 4 negatives:
   1
   1
@@ -263,7 +262,7 @@ true
 Bundling accumulates counts; `normalize` clamps back to `{-1, 0, +1}`:
 
 ```jldoctest
-julia> x = TernaryHV(; D = 8, seed = 1, rng = Xoshiro); y = TernaryHV(; D = 8, seed = 2, rng = Xoshiro);
+julia> x = TernaryHV(; D = 8, rng = Xoshiro(1)); y = TernaryHV(; D = 8, rng = Xoshiro(2));
 
 julia> x + y
 8-element TernaryHV{Int64} with 3 positives, 2 zeros, and 3 negatives:
@@ -313,38 +312,36 @@ TernaryHV(v::AbstractVector{T}) where {T<:Integer} = TernaryHV{T}(v)
 function TernaryHV(;
     D::Integer=10_000,
     seed::Union{Integer,Nothing}=nothing,
-    rng=Random.MersenneTwister
+    rng::AbstractRNG=Random.default_rng()
 )
-    rng_instance = isnothing(seed) ? rng() : rng(seed)
+    rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return TernaryHV{Int}(rand(rng_instance, (-1, 1), D))
 end
 
 function TernaryHV(
     this::Any;
-    D::Integer=10_000,
-    rng=Random.MersenneTwister
+    D::Integer=10_000
 )
     warn_integer_token(TernaryHV, this)
-    rng_instance = rng(hash(this))
+    rng_instance = Xoshiro(hash(this))
     return TernaryHV{Int}(rand(rng_instance, (-1, 1), D))
 end
 
 function TernaryHV{T}(;
     D::Integer=10_000,
     seed::Union{Integer,Nothing}=nothing,
-    rng=Random.MersenneTwister
+    rng::AbstractRNG=Random.default_rng()
 ) where {T<:Integer}
-    rng_instance = isnothing(seed) ? rng() : rng(seed)
+    rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return TernaryHV{T}(convert(Vector{T}, rand(rng_instance, (-1, 1), D)))
 end
 
 function TernaryHV{T}(
     this::Any;
-    D::Integer=10_000,
-    rng=Random.MersenneTwister
+    D::Integer=10_000
 ) where {T<:Integer}
     warn_integer_token(TernaryHV{T}, this)
-    rng_instance = rng(hash(this))
+    rng_instance = Xoshiro(hash(this))
     return TernaryHV{T}(convert(Vector{T}, rand(rng_instance, (-1, 1), D)))
 end
 
@@ -356,12 +353,12 @@ eldist(::Type{<:TernaryHV}) = 2Bernoulli(0.5) - 1
 
 # ------------------------------------------------------------------------------------ BinaryHV
 """
-    BinaryHV(; D = 10_000, seed = nothing, rng = <<<DECIDE>>>)
-    BinaryHV(this; D = 10_000, rng = <<<DECIDE>>>)
+    BinaryHV(; D = 10_000, seed = nothing, rng = Random.default_rng())
+    BinaryHV(this; D = 10_000)
     BinaryHV(v::AbstractVector{Bool})
 
 A binary hypervector implementing the Binary Spatter Code (BSC) vector symbolic
-architecture (Kanerva, 1994–1997). Elements are `<<<DECIDE: {0,1} or {false,true}>>>`,
+architecture (Kanerva, 1994–1997). Elements are `{false,true}`,
 stored compactly as a `BitVector`.
 
 Under BSC, `bind` is elementwise XOR and self-inverse (binding by the same
@@ -376,7 +373,7 @@ seed the vector — and is *never* a dimension. Set dimensionality with the keyw
 # Examples
 
 ```jldoctest
-julia> BinaryHV(; D = 8, seed = 42, rng = Xoshiro)
+julia> BinaryHV(; D = 8, rng = Xoshiro(42))
 8-element BinaryHV with 3 true and 5 false:
  0
  0
@@ -394,7 +391,7 @@ true
 Binding is self-inverse:
 
 ```jldoctest
-julia> x = BinaryHV(; D = 8, seed = 1, rng = Xoshiro); y = BinaryHV(; D = 8, seed = 2, rng = Xoshiro);
+julia> x = BinaryHV(; D = 8, rng = Xoshiro(1)); y = BinaryHV(; D = 8, rng = Xoshiro(2));
 
 julia> x * y * y == x
 true
@@ -422,19 +419,18 @@ end
 function BinaryHV(;
     D::Integer=10_000,
     seed::Union{Integer,Nothing}=nothing,
-    rng=Random.MersenneTwister
+    rng::AbstractRNG=Random.default_rng()
 )
-    rng_instance = isnothing(seed) ? rng() : rng(seed)
+    rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return BinaryHV(bitrand(rng_instance, D))
 end
 
 function BinaryHV(
     this::Any;
-    D::Integer=10_000,
-    rng=Random.MersenneTwister
+    D::Integer=10_000
 )
     warn_integer_token(BinaryHV, this)
-    rng_instance = rng(hash(this))
+    rng_instance = Xoshiro(hash(this))
     return BinaryHV(bitrand(rng_instance, D))
 end
 
@@ -445,8 +441,8 @@ eldist(::Type{BinaryHV}) = Bernoulli(0.5)
 
 # --------------------------------------------------------------------------------------- RealHV
 """
-    RealHV(; D = 10_000, distr = Normal(), seed = nothing, rng = <<<DECIDE>>>)
-    RealHV(this; D = 10_000, distr = Normal(), rng = <<<DECIDE>>>)
+    RealHV(; D = 10_000, distr = Normal(), seed = nothing, rng = Random.default_rng())
+    RealHV(this; D = 10_000, distr = Normal())
     RealHV(v::AbstractVector{<:Real}[, distr])
 
 A real-valued hypervector (continuous Multiply-Add-Permute architecture). Elements
@@ -466,7 +462,7 @@ seed the vector — and is *never* a dimension. Set dimensionality with the keyw
 # Examples
 
 ```jldoctest
-julia> RealHV(; D = 8, seed = 42, rng = Xoshiro)
+julia> RealHV(; D = 8, rng = Xoshiro(42))
 8-element RealHV{Float64} with μ ± σ = -0.222 ± 0.736:
  -0.36335748145177754
   0.2517372155742292
@@ -484,7 +480,7 @@ true
 The `distr` keyword controls the element distribution:
 
 ```jldoctest
-julia> RealHV(; D = 8, distr = Normal(0, 5), seed = 1, rng = Xoshiro)
+julia> RealHV(; D = 8, distr = Normal(0, 5), rng = Xoshiro(1))
 8-element RealHV{Float64} with μ ± σ = 0.214 ± 4.17:
   0.30966370157040063
   1.392029070820001
@@ -515,20 +511,19 @@ function RealHV(;
     distr::Distribution=eldist(RealHV),
     D::Integer=10_000,
     seed::Union{Integer,Nothing}=nothing,
-    rng=Random.MersenneTwister
+    rng::AbstractRNG=Random.default_rng()
 )
-    rng_instance = isnothing(seed) ? rng() : rng(seed)
+    rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return RealHV(rand(rng_instance, distr, D), distr)
 end
 
 function RealHV(
     this::Any;
     D::Integer=10_000,
-    distr::Distribution=eldist(RealHV),
-    rng=Random.MersenneTwister
+    distr::Distribution=eldist(RealHV)
 )
     warn_integer_token(RealHV, this)
-    rng_instance = rng(hash(this))
+    rng_instance = Xoshiro(hash(this))
     return RealHV(rand(rng_instance, distr, D), distr)
 end
 
@@ -544,8 +539,8 @@ eldist(::Type{<:RealHV}) = Normal()
 
 # -------------------------------------------------------------------------------------- GradedHV
 """
-    GradedHV(; D = 10_000, distr = Beta(1, 1), seed = nothing, rng = <<<DECIDE>>>)
-    GradedHV(this; D = 10_000, distr = Beta(1, 1), rng = <<<DECIDE>>>)
+    GradedHV(; D = 10_000, distr = Beta(1, 1), seed = nothing, rng = Random.default_rng())
+    GradedHV(this; D = 10_000, distr = Beta(1, 1))
     GradedHV(v::AbstractVector{<:Real}[, distr])
 
 A graded hypervector with elements in the fuzzy-membership interval `[0, 1]`.
@@ -565,7 +560,7 @@ seed the vector — and is *never* a dimension. Set dimensionality with the keyw
 # Examples
 
 ```jldoctest
-julia> GradedHV(; D = 8, seed = 42, rng = Xoshiro)
+julia> GradedHV(; D = 8, rng = Xoshiro(42))
 8-element GradedHV{Float64} with μ ± σ = 0.532 ± 0.247:
  0.8023279156644033
  0.6042216741680727
@@ -609,22 +604,21 @@ function GradedHV(;
     D::Integer=10_000,
     distr::Distribution=eldist(GradedHV),
     seed::Union{Integer,Nothing}=nothing,
-    rng=Random.MersenneTwister
+    rng::AbstractRNG=Random.default_rng()
 )
     @assert 0 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [0,1]"
-    rng_instance = isnothing(seed) ? rng() : rng(seed)
+    rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return GradedHV(rand(rng_instance, distr, D), distr)
 end
 
 function GradedHV(
     this::Any;
     D::Integer=10_000,
-    distr::Distribution=eldist(GradedHV),
-    rng=Random.MersenneTwister
+    distr::Distribution=eldist(GradedHV)
 )
     @assert 0 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [0,1]"
     warn_integer_token(GradedHV, this)
-    rng_instance = rng(hash(this))
+    rng_instance = Xoshiro(hash(this))
     return GradedHV(rand(rng_instance, distr, D), distr)
 end
 
@@ -639,8 +633,8 @@ empty_vector(hv::GradedHV) = fill!(zero(hv.v), 0.5)
 
 # -------------------------------------------------------------------------------- GradedBipolarHV
 """
-    GradedBipolarHV(; D = 10_000, distr = 2Beta(1, 1) - 1, seed = nothing, rng = <<<DECIDE>>>)
-    GradedBipolarHV(this; D = 10_000, distr = 2Beta(1, 1) - 1, rng = <<<DECIDE>>>)
+    GradedBipolarHV(; D = 10_000, distr = 2Beta(1, 1) - 1, seed = nothing, rng = Random.default_rng())
+    GradedBipolarHV(this; D = 10_000, distr = 2Beta(1, 1) - 1)
     GradedBipolarHV(v::AbstractVector{<:Real}[, distr])
 
 A graded bipolar hypervector with elements in `[-1, 1]`, the bipolar counterpart of
@@ -661,7 +655,7 @@ seed the vector — and is *never* a dimension. Set dimensionality with the keyw
 # Examples
 
 ```jldoctest
-julia> GradedBipolarHV(; D = 8, seed = 42, rng = Xoshiro)
+julia> GradedBipolarHV(; D = 8, rng = Xoshiro(42))
 8-element GradedBipolarHV{Float64} with μ ± σ = 0.064 ± 0.494:
   0.6046558313288066
   0.20844334833614542
@@ -704,22 +698,21 @@ function GradedBipolarHV(;
     D::Integer=10_000,
     distr::Distribution=eldist(GradedBipolarHV),
     seed::Union{Integer,Nothing}=nothing,
-    rng=Random.MersenneTwister
+    rng::AbstractRNG=Random.default_rng()
 )
     @assert -1 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [-1,1]"
-    rng_instance = isnothing(seed) ? rng() : rng(seed)
+    rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return GradedBipolarHV(rand(rng_instance, distr, D), distr)
 end
 
 function GradedBipolarHV(
     this::Any;
     D::Integer=10_000,
-    distr::Distribution=eldist(GradedBipolarHV),
-    rng=Random.MersenneTwister
+    distr::Distribution=eldist(GradedBipolarHV)
 )
     @assert -1 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [-1,1]"
     warn_integer_token(GradedBipolarHV, this)
-    rng_instance = rng(hash(this))
+    rng_instance = Xoshiro(hash(this))
     return GradedBipolarHV(rand(rng_instance, distr, D), distr)
 end
 
@@ -733,8 +726,8 @@ eldist(::Type{<:GradedBipolarHV}) = 2Beta(1, 1) - 1
 # --------------------------------------------
 
 """
-    FHRR(; D = 10_000, T = Float64, seed = nothing, rng = <<<DECIDE>>>)
-    FHRR(this; D = 10_000, T = Float64, rng = <<<DECIDE>>>)
+    FHRR(; D = 10_000, T = Float64, seed = nothing, rng = Random.default_rng())
+    FHRR(this; D = 10_000, T = Float64)
     FHRR(v::AbstractVector{<:Complex})
 
 A Fourier Holographic Reduced Representation hypervector (Plate, 1995). Elements are
@@ -755,7 +748,7 @@ seed the vector — and is *never* a dimension. Set dimensionality with the keyw
 # Examples
 
 ```jldoctest
-julia> FHRR(; D = 4, seed = 42, rng = Xoshiro)
+julia> FHRR(; D = 4, rng = Xoshiro(42))
 4-element FHRR{ComplexF64} with μ ± σ = -0.73 - 0.309im ± 0.704:
  -0.6875407989187119 - 0.7261457497102214im
  -0.9517124499338168 + 0.3069908999318585im
@@ -769,7 +762,7 @@ true
 Fractional powers encode continuous values: nearby exponents stay similar.
 
 ```jldoctest
-julia> x = FHRR(; seed = 1, rng = Xoshiro);
+julia> x = FHRR(; rng = Xoshiro(1));
 
 julia> similarity(x^1.0, x^1.05) > similarity(x^1.0, x^2.0)
 true
@@ -793,15 +786,15 @@ function FHRR(;
     D::Integer=10_000,
     T::Type=Float64,
     seed::Union{Integer,Nothing}=nothing,
-    rng=Random.MersenneTwister
+    rng::AbstractRNG=Random.default_rng()
 )
-    rng_instance = isnothing(seed) ? rng() : rng(seed)
+    rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return FHRR(exp.(2π * im .* rand(rng_instance, T, D)))
 end
 
-function FHRR(this::Any; D::Integer=10_000, T::Type=Float64, rng=Random.MersenneTwister)
+function FHRR(this::Any; D::Integer=10_000, T::Type=Float64)
     warn_integer_token(FHRR, this)
-    return FHRR(; T=T, D=D, seed=hash(this), rng=rng)
+    return FHRR(; T=T, D=D, seed=hash(this))
 end
 
 Base.similar(hv::FHRR{<:Complex{R}}) where {R} = FHRR(exp.(2π * im .* rand(R, length(hv))))

--- a/src/types.jl
+++ b/src/types.jl
@@ -34,26 +34,20 @@ rather than located in individual elements. Hypervectors are composed with
 [`bundle`](@ref) (`+`), [`bind`](@ref) (`*`) and `shift` (`ρ`), and compared with
 [`similarity`](@ref).
 
-# Constructor convention
+# Constructors and `encode`
 
-All concrete hypervector types `HV <: AbstractHV` share the same constructor interface:
+All concrete hypervector types `HV <: AbstractHV` share the same constructor
+interface, and each constructor form has exactly one meaning:
 
-    HV(; D = 10_000, seed = nothing, rng = default_rng())
-    HV(this; D = 10_000)
-    HV(v::AbstractVector)
+    HV(; D = 10_000, seed = nothing, rng = default_rng())   # fresh random hypervector
+    HV(v::AbstractVector{<:Real})                           # wrap element data, validated per type
+    HV(x)                                                   # token shorthand for `encode(HV, x)`
 
-- `HV()` creates a fresh random hypervector. The dimensionality is set with the
-  keyword `D` (default 10,000); pass an integer `seed` for reproducibility.
-- `HV(this)` creates the *deterministic* hypervector encoding the object `this`,
-  seeded by `hash(this)`. Any token — a `Symbol`, `String`, `Char`, number, etc. —
-  gets its own reproducible, quasi-orthogonal hypervector.
-- `HV(v::AbstractVector)` wraps existing data in a hypervector.
-
-!!! warning
-    The positional argument is **always the object to encode, never a dimension**.
-    `BinaryHV(6)` is the 10,000-dimensional hypervector encoding the number `6`;
-    to set the dimensionality, use the keyword: `BinaryHV(; D = 6)`. To guard
-    against this mix-up, encoding an `Integer` emits a one-time warning per session.
+[`encode`](@ref) is the canonical way to turn raw data into hypervectors — `HV(x)`
+is shorthand for its token path only. `HV(n::Number)` throws, because a number is
+ambiguous between a token and the dimensionality (use `D = n`, or `encode(HV, n)`
+for number tokens); an array that is not valid element data for the type throws
+instead of silently token-encoding. Tuples of reals read as data, like vectors.
 
 Some types extend this interface with type-specific keywords, e.g. `distr` for
 [`RealHV`](@ref), [`GradedHV`](@ref) and [`GradedBipolarHV`](@ref).
@@ -83,7 +77,7 @@ julia> length(BinaryHV(:cat; D = 100))    # dimensionality is set with the keywo
 
 # See also
 
-[`bundle`](@ref), [`bind`](@ref), [`similarity`](@ref)
+[`encode`](@ref), [`bundle`](@ref), [`bind`](@ref), [`similarity`](@ref)
 
 # Extended help
 
@@ -110,23 +104,36 @@ normalize(hv::AbstractHV) = (c = copy(hv); normalize!(c); c)
 eldist(hv::AbstractHV) = eldist(typeof(hv))
 empty_vector(hv::AbstractHV) = zero(hv.v)
 
-# The positional constructor argument is the object to encode, never a dimension.
-# Integers are the common mix-up (`BinaryHV(6)` is not 6-dimensional), so the token
-# constructors emit a one-time warning for them; Bools are exempt.
-warn_integer_token(HV::Type, this) = nothing
-warn_integer_token(HV::Type, this::Bool) = nothing
-function warn_integer_token(HV::Type, this::Integer)
-    @warn "`$HV($this)` encodes the *object* `$this` as a hypervector — the positional " *
-        "argument is never the dimensionality. Use `$HV(; D = $this)` to set the number " *
-        "of dimensions instead. (This warning is only shown once per session.)" maxlog = 1 _id = :hv_integer_token
-    return nothing
+# Constructor sugar and guardrails. `HV(x)` is shorthand for `encode(HV, x)` —
+# the token path. A `Number` is irreducibly ambiguous with the dimensionality
+# and throws. An array that reaches the generic method is not valid element
+# data for the type and throws rather than silently token-encoding
+# (constructing from an array always means data; use `encode` for array
+# tokens). A tuple of reals reads as data, like a vector.
+(HV::Type{<:AbstractHV})(x; kwargs...) = encode(HV, x; kwargs...)
+(HV::Type{<:AbstractHV})(t::Tuple{Vararg{Real}}; kwargs...) = HV(collect(t); kwargs...)
+function (HV::Type{<:AbstractHV})(n::Number; kwargs...)
+    throw(
+        ArgumentError(
+            "`$HV($n)` is ambiguous. For a $n-dimensional random hypervector, use " *
+                "`$HV(; D = $n)`. To encode the number $n as a token, use `encode($HV, $n)`."
+        )
+    )
+end
+function (HV::Type{<:AbstractHV})(v::AbstractArray; kwargs...)
+    throw(
+        ArgumentError(
+            "`$HV` cannot be constructed from a $(typeof(v)): it is not valid element " *
+                "data for this type. Use `encode($HV, x)` to token-encode arbitrary objects."
+        )
+    )
 end
 
 
 # ------------------------------------------------------------------------------------ BipolarHV
 """
     BipolarHV(; D = 10_000, seed = nothing, rng = default_rng())
-    BipolarHV(this; D = 10_000)
+    BipolarHV(x)
     BipolarHV(v::AbstractVector{<:Real})
     BipolarHV(v::AbstractVector{Bool})
 
@@ -135,20 +142,20 @@ architecture (Gayler, 1998). Elements are `±1`, stored compactly as a `BitVecto
 with bit `true ↦ -1` and `false ↦ +1`, so that XOR on the stored bits is exactly
 the elementwise `±1` product.
 
-Constructing from a real vector takes the **sign** of each element; a zero element
-throws an `ArgumentError`, since a bipolar hypervector has no zero state — use
-[`TernaryHV`](@ref) for elements in `{-1, 0, +1}`. A `Bool` vector is the exception:
-it is interpreted as the **raw stored bits** (`true ↦ -1`), not as values.
+Constructing from a real vector requires every element to be exactly `±1`; a zero
+element throws an `ArgumentError`, since a bipolar hypervector has no zero state —
+use [`TernaryHV`](@ref) for elements in `{-1, 0, +1}` — and anything else is
+rejected rather than coerced. A `Bool` vector is the exception: it is interpreted
+as the **raw stored bits** (`true ↦ -1`), not as values.
 
 Under this architecture, `bind` is the elementwise product (XOR on the stored
 bits) and self-inverse — `x * x` is the all-`+1` identity — `bundle` is a
 majority vote across inputs with deterministic tie-breaking, and `similarity`
 defaults to cosine.
 
-The positional argument `this` is always the **object to encode** — it is hashed to
-seed the vector — and is *never* a dimension. Set dimensionality with the keyword
-`D`. Encoding the same object twice yields the same hypervector. See
-[`AbstractHV`](@ref) for the full convention.
+`HV(x)` is shorthand for [`encode`](@ref)`(HV, x)`, the deterministic token path;
+a `Number` argument throws — use `D = n` for dimensionality, or `encode` for
+number tokens. See [`AbstractHV`](@ref) for the full convention.
 
 Indexing with a scalar returns a single element; indexing with a range or vector
 returns a plain `Vector`, not a hypervector.
@@ -205,26 +212,20 @@ function BipolarHV(;
     return BipolarHV(bitrand(rng_instance, D))
 end
 
-function BipolarHV(
-        this::Any;
-        D::Integer = 10_000
-    )
-    warn_integer_token(BipolarHV, this)
-    rng_instance = Xoshiro(hash(this))
-    return BipolarHV(bitrand(rng_instance, D))
-end
-
-# Data constructor: the sign of each element decides the polarity. Zero has no
-# bipolar state, so it throws rather than letting a comparison operator decide
-# silently (that arbitrariness is what caused the polarity bug). Note that Bool
-# vectors do NOT take this path: they hit the inner constructor and are treated
-# as the raw stored bits.
+# Data constructor: elements must be exactly ±1. Zero has no bipolar state and
+# points to TernaryHV; anything else is rejected rather than coerced (silent
+# sign-taking is how the polarity bug family started). Note that Bool vectors
+# do NOT take this path: they hit the inner constructor and are treated as the
+# raw stored bits.
 function BipolarHV(v::AbstractVector{<:Real})
     any(iszero, v) && throw(
         ArgumentError(
             "bipolar hypervectors have no zero state; a zero element cannot be " *
                 "mapped to ±1. Use `TernaryHV` for hypervectors with elements in {-1, 0, +1}."
         )
+    )
+    all(x -> x == 1 || x == -1, v) || throw(
+        ArgumentError("BipolarHV elements must be -1 or +1")
     )
     return BipolarHV(v .< 0)
 end
@@ -241,8 +242,8 @@ eldist(::Type{BipolarHV}) = 2Bernoulli(0.5) - 1
 # ------------------------------------------------------------------------------------ TernaryHV
 """
     TernaryHV(; D = 10_000, seed = nothing, rng = default_rng())
-    TernaryHV(this; D = 10_000)
-    TernaryHV(v::AbstractVector{<:Integer})
+    TernaryHV(x)
+    TernaryHV(v::AbstractVector{<:Real})
     TernaryHV{T}(...)
 
 A ternary hypervector implementing the Multiply-Add-Permute (MAP) vector symbolic
@@ -256,10 +257,9 @@ elementwise addition *without* normalization by default (so counts accumulate;
 `normalize` clamps the result back to `{-1, 0, +1}`), and `similarity` defaults to
 cosine.
 
-The positional argument `this` is always the **object to encode** — it is hashed to
-seed the vector — and is *never* a dimension. Set dimensionality with the keyword
-`D`. Encoding the same object twice yields the same hypervector. See
-[`AbstractHV`](@ref) for the full convention.
+`HV(x)` is shorthand for [`encode`](@ref)`(HV, x)`, the deterministic token path;
+a `Number` argument throws — use `D = n` for dimensionality, or `encode` for
+number tokens. See [`AbstractHV`](@ref) for the full convention.
 
 Indexing with a scalar returns a single element; indexing with a range or vector
 returns a plain `Vector`, not a hypervector.
@@ -329,8 +329,17 @@ struct TernaryHV{T <: Integer} <: AbstractHV{T}
     TernaryHV{T}(v::AbstractVector{<:Integer}) where {T <: Integer} = new{T}(convert(Vector{T}, v))
 end
 
-# Outer constructor that infers type from input
-TernaryHV(v::AbstractVector{T}) where {T <: Integer} = TernaryHV{T}(v)
+# Data constructors validate the ternary domain. The inner `TernaryHV{T}`
+# constructors stay permissive on purpose: operations legitimately exceed the
+# domain (unnormalized bundling accumulates counts).
+function TernaryHV(v::AbstractVector{T}) where {T <: Integer}
+    all(x -> -1 ≤ x ≤ 1, v) || throw(ArgumentError("TernaryHV elements must be -1, 0, or +1"))
+    return TernaryHV{T}(v)
+end
+function TernaryHV(v::AbstractVector{<:Real})
+    all(x -> x == -1 || x == 0 || x == 1, v) || throw(ArgumentError("TernaryHV elements must be -1, 0, or +1"))
+    return TernaryHV{Int}(convert(Vector{Int}, v))
+end
 
 function TernaryHV(;
         D::Integer = 10_000,
@@ -338,15 +347,6 @@ function TernaryHV(;
         rng::AbstractRNG = Random.default_rng()
     )
     rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
-    return TernaryHV{Int}(rand(rng_instance, (-1, 1), D))
-end
-
-function TernaryHV(
-        this::Any;
-        D::Integer = 10_000
-    )
-    warn_integer_token(TernaryHV, this)
-    rng_instance = Xoshiro(hash(this))
     return TernaryHV{Int}(rand(rng_instance, (-1, 1), D))
 end
 
@@ -359,15 +359,6 @@ function TernaryHV{T}(;
     return TernaryHV{T}(convert(Vector{T}, rand(rng_instance, (-1, 1), D)))
 end
 
-function TernaryHV{T}(
-        this::Any;
-        D::Integer = 10_000
-    ) where {T <: Integer}
-    warn_integer_token(TernaryHV{T}, this)
-    rng_instance = Xoshiro(hash(this))
-    return TernaryHV{T}(convert(Vector{T}, rand(rng_instance, (-1, 1), D)))
-end
-
 # Helpers
 Base.copy(hv::TernaryHV{T}) where {T} = TernaryHV{T}(copy(hv.v))
 Base.similar(hv::TernaryHV{T}) where {T} = TernaryHV{T}(; D = length(hv))
@@ -377,8 +368,8 @@ eldist(::Type{<:TernaryHV}) = 2Bernoulli(0.5) - 1
 # ------------------------------------------------------------------------------------ BinaryHV
 """
     BinaryHV(; D = 10_000, seed = nothing, rng = default_rng())
-    BinaryHV(this; D = 10_000)
-    BinaryHV(v::AbstractVector{Bool})
+    BinaryHV(x)
+    BinaryHV(v::AbstractVector{<:Real})
 
 A binary hypervector implementing the Binary Spatter Code (BSC) vector symbolic
 architecture (Kanerva, 1994–1997). Elements are `{false,true}`,
@@ -388,10 +379,9 @@ Under BSC, `bind` is elementwise XOR and self-inverse (`x * x` is the identity
 element), `bundle` is a majority vote across inputs with
 deterministic tie-breaking, and `similarity` defaults to Jaccard.
 
-The positional argument `this` is always the **object to encode** — it is hashed to
-seed the vector — and is *never* a dimension. Set dimensionality with the keyword
-`D`. Encoding the same object twice yields the same hypervector. See
-[`AbstractHV`](@ref) for the full convention.
+`HV(x)` is shorthand for [`encode`](@ref)`(HV, x)`, the deterministic token path;
+a `Number` argument throws — use `D = n` for dimensionality, or `encode` for
+number tokens. See [`AbstractHV`](@ref) for the full convention.
 
 Indexing with a scalar returns a single element; indexing with a range or vector
 returns a plain `Vector`, not a hypervector.
@@ -451,13 +441,11 @@ function BinaryHV(;
     return BinaryHV(bitrand(rng_instance, D))
 end
 
-function BinaryHV(
-        this::Any;
-        D::Integer = 10_000
-    )
-    warn_integer_token(BinaryHV, this)
-    rng_instance = Xoshiro(hash(this))
-    return BinaryHV(bitrand(rng_instance, D))
+# Data constructor: elements must be Boolean-valued (0/1); Bool vectors hit
+# the inner constructor directly.
+function BinaryHV(v::AbstractVector{<:Real})
+    all(x -> iszero(x) || isone(x), v) || throw(ArgumentError("BinaryHV elements must be 0 or 1"))
+    return BinaryHV(BitVector(v .== 1))
 end
 
 # Helpers
@@ -468,7 +456,7 @@ eldist(::Type{BinaryHV}) = Bernoulli(0.5)
 # --------------------------------------------------------------------------------------- RealHV
 """
     RealHV(; D = 10_000, distr = Normal(), seed = nothing, rng = default_rng())
-    RealHV(this; D = 10_000, distr = Normal())
+    RealHV(x)
     RealHV(v::AbstractVector{<:Real}[, distr])
 
 A real-valued hypervector (continuous Multiply-Add-Permute architecture). Elements
@@ -483,10 +471,9 @@ to cosine. Real-valued MAP binding is not exactly invertible, so [`unbind`](@ref
 against candidate hypervectors, or use [`FHRR`](@ref) or [`BipolarHV`](@ref) if
 you need exact unbinding.
 
-The positional argument `this` is always the **object to encode** — it is hashed to
-seed the vector — and is *never* a dimension. Set dimensionality with the keyword
-`D`. Encoding the same object twice yields the same hypervector. See
-[`AbstractHV`](@ref) for the full convention.
+`HV(x)` is shorthand for [`encode`](@ref)`(HV, x)`, the deterministic token path;
+a `Number` argument throws — use `D = n` for dimensionality, or `encode` for
+number tokens. See [`AbstractHV`](@ref) for the full convention.
 
 Indexing with a scalar returns a single element; indexing with a range or vector
 returns a plain `Vector`, not a hypervector.
@@ -549,16 +536,6 @@ function RealHV(;
     return RealHV(rand(rng_instance, distr, D), distr)
 end
 
-function RealHV(
-        this::Any;
-        D::Integer = 10_000,
-        distr::Distribution = eldist(RealHV)
-    )
-    warn_integer_token(RealHV, this)
-    rng_instance = Xoshiro(hash(this))
-    return RealHV(rand(rng_instance, distr, D), distr)
-end
-
 # Helpers
 Base.copy(hv::RealHV) = RealHV(copy(hv.v), hv.distr)
 Base.similar(hv::RealHV) = RealHV(; D = length(hv), distr = hv.distr)
@@ -572,7 +549,7 @@ eldist(::Type{<:RealHV}) = Normal()
 # -------------------------------------------------------------------------------------- GradedHV
 """
     GradedHV(; D = 10_000, distr = Beta(1, 1), seed = nothing, rng = default_rng())
-    GradedHV(this; D = 10_000, distr = Beta(1, 1))
+    GradedHV(x)
     GradedHV(v::AbstractVector{<:Real}[, distr])
 
 A graded hypervector with elements in the fuzzy-membership interval `[0, 1]`.
@@ -584,10 +561,9 @@ Operations follow fuzzy logic: `bind` is the fuzzy XOR
 `(1 - x) * y + x * (1 - y)`, `bundle` uses the three-valued π aggregation, and
 `similarity` defaults to Jaccard.
 
-The positional argument `this` is always the **object to encode** — it is hashed to
-seed the vector — and is *never* a dimension. Set dimensionality with the keyword
-`D`. Encoding the same object twice yields the same hypervector. See
-[`AbstractHV`](@ref) for the full convention.
+`HV(x)` is shorthand for [`encode`](@ref)`(HV, x)`, the deterministic token path;
+a `Number` argument throws — use `D = n` for dimensionality, or `encode` for
+number tokens. See [`AbstractHV`](@ref) for the full convention.
 
 Indexing with a scalar returns a single element; indexing with a range or vector
 returns a plain `Vector`, not a hypervector.
@@ -628,10 +604,13 @@ struct GradedHV{T <: Real} <: AbstractHV{T}
     v::Vector{T}
     distr::Distribution
 
-    GradedHV(
-        v::AbstractVector{T},
-        distr::Distribution = eldist(GradedHV)
-    ) where {T <: Real} = new{T}(clamp.(v, 0, 1), distr)
+    function GradedHV(
+            v::AbstractVector{T},
+            distr::Distribution = eldist(GradedHV)
+        ) where {T <: Real}
+        all(x -> 0 ≤ x ≤ 1, v) || throw(ArgumentError("GradedHV elements must lie in [0, 1]"))
+        return new{T}(v, distr)
+    end
 end
 
 # Constructors
@@ -643,17 +622,6 @@ function GradedHV(;
     )
     @assert 0 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [0,1]"
     rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
-    return GradedHV(rand(rng_instance, distr, D), distr)
-end
-
-function GradedHV(
-        this::Any;
-        D::Integer = 10_000,
-        distr::Distribution = eldist(GradedHV)
-    )
-    @assert 0 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [0,1]"
-    warn_integer_token(GradedHV, this)
-    rng_instance = Xoshiro(hash(this))
     return GradedHV(rand(rng_instance, distr, D), distr)
 end
 
@@ -669,7 +637,7 @@ empty_vector(hv::GradedHV) = fill!(zero(hv.v), 0.5)
 # -------------------------------------------------------------------------------- GradedBipolarHV
 """
     GradedBipolarHV(; D = 10_000, distr = 2Beta(1, 1) - 1, seed = nothing, rng = default_rng())
-    GradedBipolarHV(this; D = 10_000, distr = 2Beta(1, 1) - 1)
+    GradedBipolarHV(x)
     GradedBipolarHV(v::AbstractVector{<:Real}[, distr])
 
 A graded bipolar hypervector with elements in `[-1, 1]`, the bipolar counterpart of
@@ -682,10 +650,9 @@ bipolar interval: `bind` is fuzzy XOR and `bundle` the three-valued π aggregati
 both applied after rescaling `[-1, 1]` to `[0, 1]` and mapping back; `similarity`
 defaults to cosine.
 
-The positional argument `this` is always the **object to encode** — it is hashed to
-seed the vector — and is *never* a dimension. Set dimensionality with the keyword
-`D`. Encoding the same object twice yields the same hypervector. See
-[`AbstractHV`](@ref) for the full convention.
+`HV(x)` is shorthand for [`encode`](@ref)`(HV, x)`, the deterministic token path;
+a `Number` argument throws — use `D = n` for dimensionality, or `encode` for
+number tokens. See [`AbstractHV`](@ref) for the full convention.
 
 Indexing with a scalar returns a single element; indexing with a range or vector
 returns a plain `Vector`, not a hypervector.
@@ -726,10 +693,13 @@ struct GradedBipolarHV{T <: Real} <: AbstractHV{T}
     v::Vector{T}
     distr::Distribution
 
-    GradedBipolarHV(
-        v::AbstractVector{T},
-        distr::Distribution = eldist(GradedBipolarHV)
-    ) where {T <: Real} = new{T}(clamp.(v, -1, 1), distr)
+    function GradedBipolarHV(
+            v::AbstractVector{T},
+            distr::Distribution = eldist(GradedBipolarHV)
+        ) where {T <: Real}
+        all(x -> -1 ≤ x ≤ 1, v) || throw(ArgumentError("GradedBipolarHV elements must lie in [-1, 1]"))
+        return new{T}(v, distr)
+    end
 end
 
 function GradedBipolarHV(;
@@ -740,17 +710,6 @@ function GradedBipolarHV(;
     )
     @assert -1 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [-1,1]"
     rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
-    return GradedBipolarHV(rand(rng_instance, distr, D), distr)
-end
-
-function GradedBipolarHV(
-        this::Any;
-        D::Integer = 10_000,
-        distr::Distribution = eldist(GradedBipolarHV)
-    )
-    @assert -1 ≤ minimum(distr) < maximum(distr) ≤ 1 "Provide `distr` with support in [-1,1]"
-    warn_integer_token(GradedBipolarHV, this)
-    rng_instance = Xoshiro(hash(this))
     return GradedBipolarHV(rand(rng_instance, distr, D), distr)
 end
 
@@ -765,7 +724,7 @@ eldist(::Type{<:GradedBipolarHV}) = 2Beta(1, 1) - 1
 
 """
     FHRR(; D = 10_000, T = Float64, seed = nothing, rng = default_rng())
-    FHRR(this; D = 10_000, T = Float64)
+    FHRR(x)
     FHRR(v::AbstractVector{<:Complex})
 
 A Fourier Holographic Reduced Representation hypervector (Plate, 1995). Elements are
@@ -778,10 +737,9 @@ unit modulus, and `similarity` is the normalized real part of the complex dot
 product. In addition, `hv ^ x` raises every phase to the power `x`, which enables
 fractional-power (level) encoding of continuous values.
 
-The positional argument `this` is always the **object to encode** — it is hashed to
-seed the vector — and is *never* a dimension. Set dimensionality with the keyword
-`D`. Encoding the same object twice yields the same hypervector. See
-[`AbstractHV`](@ref) for the full convention.
+`HV(x)` is shorthand for [`encode`](@ref)`(HV, x)`, the deterministic token path;
+a `Number` argument throws — use `D = n` for dimensionality, or `encode` for
+number tokens. See [`AbstractHV`](@ref) for the full convention.
 
 Indexing with a scalar returns a single element; indexing with a range or vector
 returns a plain `Vector`, not a hypervector.
@@ -821,7 +779,16 @@ true
 """
 struct FHRR{T <: Complex} <: AbstractHV{T}
     v::Vector{T}
+
+    function FHRR{T}(v::Vector{T}) where {T <: Complex}
+        all(z -> abs(z) ≈ 1, v) || throw(
+            ArgumentError("FHRR elements must lie on the complex unit circle (unit modulus)")
+        )
+        return new{T}(v)
+    end
 end
+
+FHRR(v::AbstractVector{T}) where {T <: Complex} = FHRR{T}(convert(Vector{T}, v))
 
 function FHRR(;
         D::Integer = 10_000,
@@ -831,11 +798,6 @@ function FHRR(;
     )
     rng_instance = isnothing(seed) ? rng : Xoshiro(seed)
     return FHRR(exp.(2π * im .* rand(rng_instance, T, D)))
-end
-
-function FHRR(this::Any; D::Integer = 10_000, T::Type = Float64)
-    warn_integer_token(FHRR, this)
-    return FHRR(; T = T, D = D, seed = hash(this))
 end
 
 Base.similar(hv::FHRR{<:Complex{R}}) where {R} = FHRR(exp.(2π * im .* rand(R, length(hv))))

--- a/src/types.jl
+++ b/src/types.jl
@@ -38,7 +38,7 @@ rather than located in individual elements. Hypervectors are composed with
 
 All concrete hypervector types `HV <: AbstractHV` share the same constructor interface:
 
-    HV(; D = 10_000, seed = nothing, rng = Random.default_rng())
+    HV(; D = 10_000, seed = nothing, rng = default_rng())
     HV(this; D = 10_000)
     HV(v::AbstractVector)
 
@@ -124,7 +124,7 @@ end
 
 # ------------------------------------------------------------------------------------ BipolarHV
 """
-    BipolarHV(; D = 10_000, seed = nothing, rng = Random.default_rng())
+    BipolarHV(; D = 10_000, seed = nothing, rng = default_rng())
     BipolarHV(this; D = 10_000)
     BipolarHV(v::AbstractVector{Bool})
     BipolarHV(v::AbstractVector{<:Integer})
@@ -145,6 +145,9 @@ The positional argument `this` is always the **object to encode** — it is hash
 seed the vector — and is *never* a dimension. Set dimensionality with the keyword
 `D`. Encoding the same object twice yields the same hypervector. See
 [`AbstractHV`](@ref) for the full convention.
+
+Indexing with a scalar returns a single element; indexing with a range or vector
+returns a plain `Vector`, not a hypervector.
 
 # Examples
 
@@ -210,9 +213,9 @@ end
 BipolarHV(v::AbstractVector{<:Integer}) = BipolarHV(v .> 0)
 
 # Helpers
-Base.getindex(hv::BipolarHV, i::Integer) = hv.v[i] ? 1 : -1
-Base.getindex(hv::BipolarHV, I::AbstractVector) = ifelse.(hv.v[I], 1, -1)
-Base.sum(hv::BipolarHV) = 2sum(hv.v) - length(hv.v)
+Base.getindex(hv::BipolarHV, i::Integer) = hv.v[i] ? -1 : 1
+Base.getindex(hv::BipolarHV, I::AbstractVector) = ifelse.(hv.v[I], -1, 1)
+Base.sum(hv::BipolarHV) = length(hv.v) - 2sum(hv.v)
 LinearAlgebra.norm(hv::BipolarHV) = sqrt(length(hv))
 empty_vector(hv::BipolarHV) = zeros(Int, length(hv))
 eldist(::Type{BipolarHV}) = 2Bernoulli(0.5) - 1
@@ -220,7 +223,7 @@ eldist(::Type{BipolarHV}) = 2Bernoulli(0.5) - 1
 
 # ------------------------------------------------------------------------------------ TernaryHV
 """
-    TernaryHV(; D = 10_000, seed = nothing, rng = Random.default_rng())
+    TernaryHV(; D = 10_000, seed = nothing, rng = default_rng())
     TernaryHV(this; D = 10_000)
     TernaryHV(v::AbstractVector{<:Integer})
     TernaryHV{T}(...)
@@ -240,6 +243,9 @@ The positional argument `this` is always the **object to encode** — it is hash
 seed the vector — and is *never* a dimension. Set dimensionality with the keyword
 `D`. Encoding the same object twice yields the same hypervector. See
 [`AbstractHV`](@ref) for the full convention.
+
+Indexing with a scalar returns a single element; indexing with a range or vector
+returns a plain `Vector`, not a hypervector.
 
 # Examples
 
@@ -353,7 +359,7 @@ eldist(::Type{<:TernaryHV}) = 2Bernoulli(0.5) - 1
 
 # ------------------------------------------------------------------------------------ BinaryHV
 """
-    BinaryHV(; D = 10_000, seed = nothing, rng = Random.default_rng())
+    BinaryHV(; D = 10_000, seed = nothing, rng = default_rng())
     BinaryHV(this; D = 10_000)
     BinaryHV(v::AbstractVector{Bool})
 
@@ -361,14 +367,17 @@ A binary hypervector implementing the Binary Spatter Code (BSC) vector symbolic
 architecture (Kanerva, 1994–1997). Elements are `{false,true}`,
 stored compactly as a `BitVector`.
 
-Under BSC, `bind` is elementwise XOR and self-inverse (binding by the same
-hypervector twice undoes it), `bundle` is a majority vote across inputs with
+Under BSC, `bind` is elementwise XOR and self-inverse (`x * x` is the identity
+element), `bundle` is a majority vote across inputs with
 deterministic tie-breaking, and `similarity` defaults to Jaccard.
 
 The positional argument `this` is always the **object to encode** — it is hashed to
 seed the vector — and is *never* a dimension. Set dimensionality with the keyword
 `D`. Encoding the same object twice yields the same hypervector. See
 [`AbstractHV`](@ref) for the full convention.
+
+Indexing with a scalar returns a single element; indexing with a range or vector
+returns a plain `Vector`, not a hypervector.
 
 # Examples
 
@@ -441,7 +450,7 @@ eldist(::Type{BinaryHV}) = Bernoulli(0.5)
 
 # --------------------------------------------------------------------------------------- RealHV
 """
-    RealHV(; D = 10_000, distr = Normal(), seed = nothing, rng = Random.default_rng())
+    RealHV(; D = 10_000, distr = Normal(), seed = nothing, rng = default_rng())
     RealHV(this; D = 10_000, distr = Normal())
     RealHV(v::AbstractVector{<:Real}[, distr])
 
@@ -450,14 +459,20 @@ are drawn from a configurable distribution `distr` (standard normal by default),
 which the vector carries along so that `normalize!` can rescale a result back to
 the original spread.
 
-Under this architecture, `bind` is elementwise multiplication, inverted exactly by
-[`unbind`](@ref) (elementwise division), `bundle` is elementwise addition rescaled
-by `√m` for `m` inputs, and `similarity` defaults to cosine.
+Under this architecture, `bind` is elementwise multiplication, `bundle` is
+elementwise addition rescaled by `√m` for `m` inputs, and `similarity` defaults
+to cosine. Real-valued MAP binding is not exactly invertible, so [`unbind`](@ref)
+**throws** for this type: recover bound information with [`similarity`](@ref)
+against candidate hypervectors, or use [`FHRR`](@ref) or [`BipolarHV`](@ref) if
+you need exact unbinding.
 
 The positional argument `this` is always the **object to encode** — it is hashed to
 seed the vector — and is *never* a dimension. Set dimensionality with the keyword
 `D`. Encoding the same object twice yields the same hypervector. See
 [`AbstractHV`](@ref) for the full convention.
+
+Indexing with a scalar returns a single element; indexing with a range or vector
+returns a plain `Vector`, not a hypervector.
 
 # Examples
 
@@ -539,7 +554,7 @@ eldist(::Type{<:RealHV}) = Normal()
 
 # -------------------------------------------------------------------------------------- GradedHV
 """
-    GradedHV(; D = 10_000, distr = Beta(1, 1), seed = nothing, rng = Random.default_rng())
+    GradedHV(; D = 10_000, distr = Beta(1, 1), seed = nothing, rng = default_rng())
     GradedHV(this; D = 10_000, distr = Beta(1, 1))
     GradedHV(v::AbstractVector{<:Real}[, distr])
 
@@ -556,6 +571,9 @@ The positional argument `this` is always the **object to encode** — it is hash
 seed the vector — and is *never* a dimension. Set dimensionality with the keyword
 `D`. Encoding the same object twice yields the same hypervector. See
 [`AbstractHV`](@ref) for the full convention.
+
+Indexing with a scalar returns a single element; indexing with a range or vector
+returns a plain `Vector`, not a hypervector.
 
 # Examples
 
@@ -633,7 +651,7 @@ empty_vector(hv::GradedHV) = fill!(zero(hv.v), 0.5)
 
 # -------------------------------------------------------------------------------- GradedBipolarHV
 """
-    GradedBipolarHV(; D = 10_000, distr = 2Beta(1, 1) - 1, seed = nothing, rng = Random.default_rng())
+    GradedBipolarHV(; D = 10_000, distr = 2Beta(1, 1) - 1, seed = nothing, rng = default_rng())
     GradedBipolarHV(this; D = 10_000, distr = 2Beta(1, 1) - 1)
     GradedBipolarHV(v::AbstractVector{<:Real}[, distr])
 
@@ -651,6 +669,9 @@ The positional argument `this` is always the **object to encode** — it is hash
 seed the vector — and is *never* a dimension. Set dimensionality with the keyword
 `D`. Encoding the same object twice yields the same hypervector. See
 [`AbstractHV`](@ref) for the full convention.
+
+Indexing with a scalar returns a single element; indexing with a range or vector
+returns a plain `Vector`, not a hypervector.
 
 # Examples
 
@@ -726,7 +747,7 @@ eldist(::Type{<:GradedBipolarHV}) = 2Beta(1, 1) - 1
 # --------------------------------------------
 
 """
-    FHRR(; D = 10_000, T = Float64, seed = nothing, rng = Random.default_rng())
+    FHRR(; D = 10_000, T = Float64, seed = nothing, rng = default_rng())
     FHRR(this; D = 10_000, T = Float64)
     FHRR(v::AbstractVector{<:Complex})
 
@@ -745,11 +766,14 @@ seed the vector — and is *never* a dimension. Set dimensionality with the keyw
 `D`. Encoding the same object twice yields the same hypervector. See
 [`AbstractHV`](@ref) for the full convention.
 
+Indexing with a scalar returns a single element; indexing with a range or vector
+returns a plain `Vector`, not a hypervector.
+
 # Examples
 
 ```jldoctest
 julia> FHRR(; D = 4, rng = Xoshiro(42))
-4-element FHRR{ComplexF64} with μ ± σ = -0.73 - 0.309im ± 0.704:
+4-element FHRR{ComplexF64}:
  -0.6875407989187119 - 0.7261457497102214im
  -0.9517124499338168 + 0.3069908999318585im
  -0.9899412825080958 + 0.14147882239482543im

--- a/src/types.jl
+++ b/src/types.jl
@@ -370,7 +370,7 @@ end
 # Helpers
 Base.copy(hv::TernaryHV{T}) where {T} = TernaryHV{T}(copy(hv.v))
 Base.similar(hv::TernaryHV{T}) where {T} = TernaryHV{T}(; D=length(hv))
-normalize!(hv::TernaryHV) = clamp!(hv.v, -1, 1)
+normalize!(hv::TernaryHV) = (clamp!(hv.v, -1, 1); hv)
 eldist(::Type{<:TernaryHV}) = 2Bernoulli(0.5) - 1
 
 # ------------------------------------------------------------------------------------ BinaryHV
@@ -660,7 +660,7 @@ end
 Base.copy(hv::GradedHV) = GradedHV(copy(hv.v), hv.distr)
 Base.similar(hv::GradedHV) = GradedHV(; D=length(hv), distr=hv.distr)
 Base.zeros(hv::GradedHV) = fill!(similar(hv.v), one(eltype(hv.v)) / 2)
-normalize!(hv::GradedHV) = clamp!(hv.v, 0, 1)
+normalize!(hv::GradedHV) = (clamp!(hv.v, 0, 1); hv)
 eldist(::Type{<:GradedHV}) = Beta(1, 1)
 empty_vector(hv::GradedHV) = fill!(zero(hv.v), 0.5)
 
@@ -756,7 +756,7 @@ end
 # Helpers
 Base.copy(hv::GradedBipolarHV) = GradedBipolarHV(copy(hv.v), hv.distr)
 Base.similar(hv::GradedBipolarHV) = GradedBipolarHV(; D=length(hv), distr=hv.distr)
-normalize!(hv::GradedBipolarHV) = clamp!(hv.v, -1, 1)
+normalize!(hv::GradedBipolarHV) = (clamp!(hv.v, -1, 1); hv)
 eldist(::Type{<:GradedBipolarHV}) = 2Beta(1, 1) - 1
 
 # Fourier Holographic Reduced Representations

--- a/src/types.jl
+++ b/src/types.jl
@@ -97,7 +97,6 @@ Base.copy(hv::HV) where {HV<:AbstractHV} = HV(copy(hv.v))
 # hypervector — a slice of a hypervector is not a meaningful hypervector.
 Base.getindex(hv::AbstractHV, i::Integer) = hv.v[i]
 Base.getindex(hv::AbstractHV, I::AbstractVector) = hv.v[I]
-Base.hash(hv::AbstractHV) = hash(hv.v)
 Base.similar(hv::HV) where {HV<:AbstractHV} = HV(; D=length(hv))
 Base.size(hv::AbstractHV) = size(hv.v)
 Base.sum(hv::AbstractHV) = sum(hv.v)

--- a/test/encoding.jl
+++ b/test/encoding.jl
@@ -63,6 +63,20 @@
         @test hv isa BinaryHV
         x = decoder(hv)
         @test 1 ≤ x ≤ 2
+
+        # regression (TODO §1.4): the instance-based decodelevel/convertlevel
+        # path used to throw a MethodError caused by kwarg forwarding
+        dec = decodelevel(BinaryHV(; D = 100, seed = 3), numvals)
+        @test dec isa Function
+        enc2, dec2 = convertlevel(BinaryHV(; D = 100, seed = 3), numvals)
+        @test enc2(1.0) isa BinaryHV
+        @test minimum(numvals) ≤ dec2(enc2(1.0)) ≤ maximum(numvals)
+        # keywords also forward through the shared-ladder path
+        enc3, dec3 = convertlevel(levels, numvals; testbound = true)
+        @test dec3(enc3(1.467)) isa Number
+        # NOTE (TODO §1.4b): enc2/dec2 are built over *different* random ladders,
+        # so decode(encode(x)) ≈ x does not hold on the instance path — flagged,
+        # not asserted here.
     end
 
     @testset "FHRR numbers" begin

--- a/test/encoding.jl
+++ b/test/encoding.jl
@@ -1,4 +1,51 @@
+# Extension-point demo for the encode-strategy tests: one struct, one method.
+struct ReversedSeq <: AbstractEncoding end
+function HyperdimensionalComputing.encode(HV::Type{<:AbstractHV}, x, ::ReversedSeq; kwargs...)
+    return encode(HV, reverse(collect(x)), Sequence(); kwargs...)
+end
+
 @testset "encoding" begin
+    @testset "encode strategies" begin
+        seq = "ACGTAC"
+        D = 64
+
+        # KMer: each window substring is one atomic token, bundled
+        km = encode(BinaryHV, seq, KMer(3); D = D)
+        km_ref = multiset([encode(BinaryHV, seq[i:(i + 2)]; D = D) for i in 1:4])
+        @test km == km_ref
+
+        # NGram: symbols encoded, windows composed by shift-binding (= ngrams)
+        ng = encode(BinaryHV, seq, NGram(3); D = D)
+        ng_ref = ngrams([encode(BinaryHV, c; D = D) for c in seq], 3)
+        @test ng == ng_ref
+
+        # KMer and NGram are genuinely different operations
+        @test km != ng
+
+        # the token path hashes the whole string and differs from any strategy
+        @test encode(BinaryHV, seq) == encode(BinaryHV, seq)
+        @test encode(BinaryHV, seq; D = D) != km
+
+        # Sequence and BagOfSymbols match their combinator references
+        vs = [encode(BipolarHV, c; D = D) for c in seq]
+        @test encode(BipolarHV, seq, Sequence(); D = D) == bundlesequence(vs)
+        @test encode(BipolarHV, seq, BagOfSymbols(); D = D) == multiset(vs)
+
+        # non-string sequences work too (windows are tuples of symbols)
+        v = [:a, :b, :a, :c]
+        @test encode(BinaryHV, v, KMer(2); D = D) ==
+            multiset([encode(BinaryHV, (v[i], v[i + 1]); D = D) for i in 1:3])
+
+        # argument validation
+        @test_throws ArgumentError KMer(0)
+        @test_throws ArgumentError NGram(0)
+        @test_throws ArgumentError encode(BinaryHV, "AC", KMer(3); D = D)
+
+        # extension point: a struct plus one encode method is all it takes
+        @test encode(BinaryHV, "AB", ReversedSeq(); D = D) ==
+            encode(BinaryHV, "BA", Sequence(); D = D)
+    end
+
     hvs = BinaryHV.(
         [
             Bool.([1, 0, 0, 0, 0]),
@@ -53,7 +100,7 @@
 
     @testset "levels" begin
         numvals = 0:0.1:2pi
-        levels = level(BinaryHV(100), numvals)
+        levels = level(BinaryHV(; D = 100), numvals)
 
         @test length(levels) == length(numvals)
         @test eltype(levels) <: BinaryHV

--- a/test/ext_display.jl
+++ b/test/ext_display.jl
@@ -1,0 +1,39 @@
+# Rich-display tests for the UnicodePlots package extension.
+#
+# This file runs in a SEPARATE Julia process (see runtests.jl): loading
+# UnicodePlots cannot be undone within a session, and the plain-display tests
+# in representations.jl require the extension to be absent.
+
+using Test
+using HyperdimensionalComputing
+using UnicodePlots
+
+@testset "UnicodePlots extension" begin
+    # `nothing` here would mean the extension failed to load (e.g. the
+    # precompilation failure from defining `show` in both package and extension)
+    ext = Base.get_extension(HyperdimensionalComputing, :UnicodePlotting)
+    @test ext !== nothing
+
+    hv_types = [BinaryHV, BipolarHV, TernaryHV, RealHV, GradedHV, GradedBipolarHV, FHRR]
+
+    @testset "rich show $HV" for HV in hv_types
+        hv = HV(; D = 100)
+        s = repr(MIME"text/plain"(), hv)
+        @test occursin("-element", s)   # summary header
+        @test occursin("┌", s)          # plot borders from UnicodePlots
+
+        # :compact contexts fall back to the plain display
+        c = repr(MIME"text/plain"(), hv; context = :compact => true)
+        @test !occursin("┌", c)
+    end
+
+    @testset "direct plotting API $HV" for HV in hv_types
+        hv = HV(; D = 100)
+        @test unicodeheatmap(hv) isa UnicodePlots.Plot
+        @test unicodehistogram(hv) isa UnicodePlots.Plot
+    end
+
+    # regression: displaying a BipolarHV with the extension loaded used to throw
+    # a TypeError (range indexing on the BitVector storage)
+    @test sprint(show, MIME"text/plain"(), BipolarHV(; D = 100)) isa String
+end

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -66,6 +66,11 @@
         @test similarity(x, y) == δ(x)(y)
     end
 
+    @testset "δ alias" begin
+        @test isconst(HyperdimensionalComputing, :δ)   # regression (TODO §1.7)
+        @test δ === similarity
+    end
+
     @testset "Similarity matrix" begin
         levels = level(RealHV(100), 10)
         M = similarity(levels)

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -72,7 +72,7 @@
     end
 
     @testset "Similarity matrix" begin
-        levels = level(RealHV(100), 10)
+        levels = level(RealHV(; D = 100), 10)
         M = similarity(levels)
         @test M isa Matrix
         @test size(M) == (10, 10)

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -23,10 +23,10 @@ Random.seed!(42)
             @testset "bundle $HV" begin
                 @test bundle((hv1, hv2)) isa HV
                 @test bundle([hv1, hv2]) isa HV
-                @test bundle((HV(i; D = N) for i in 1:5)) isa HV
+                @test bundle((encode(HV, i; D = N) for i in 1:5)) isa HV
                 @test hv1 + hv2 isa HV
-                @test +((HV(i; D = N) for i in 1:5)...) isa HV
-                @test +((HV(i; D = N) for i in 1:5)...) == bundle((HV(i; D = N) for i in 1:5))
+                @test +((encode(HV, i; D = N) for i in 1:5)...) isa HV
+                @test +((encode(HV, i; D = N) for i in 1:5)...) == bundle((encode(HV, i; D = N) for i in 1:5))
 
                 if HV <: Union{BinaryHV, BipolarHV}
                     @test (hv1 + hv2).v == (hv1 + hv2).v
@@ -41,9 +41,9 @@ Random.seed!(42)
             @testset "bind $HV" begin
                 @test bind(hv1, hv2) isa HV
                 @test bind([hv1, hv2]) isa HV
-                @test bind([HV(i; D = N) for i in 1:5]) isa HV
-                @test *([HV(i; D = N) for i in 1:5]...) isa HV
-                @test bind([HV(i; D = N) for i in 1:5]) == *([HV(i; D = N) for i in 1:5]...) isa HV
+                @test bind([encode(HV, i; D = N) for i in 1:5]) isa HV
+                @test *([encode(HV, i; D = N) for i in 1:5]...) isa HV
+                @test bind([encode(HV, i; D = N) for i in 1:5]) == *([encode(HV, i; D = N) for i in 1:5]...) isa HV
                 @test hv1 * hv2 isa HV
             end
 

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -129,6 +129,20 @@ Random.seed!(42)
         @test similarity(hv2, hv2) ≈ 1
 
         @test norm(hv1^3) ≈ sqrt(n)
+
+        # regression (TODO §1.3): perturbate used to throw a MethodError for FHRR;
+        # phases must be resampled so elements stay on the unit circle
+        hvp = perturbate(hv1, 10)
+        @test hvp isa FHRR
+        @test all(abs.(hvp.v) .≈ 1)
+        @test count(hvp.v .!= hv1.v) == 10   # exactly n positions resampled
+        @test perturbate(hv1, 0.2) isa FHRR
+        m = bitrand(length(hv1))
+        hvm = perturbate(hv1, m; rng = Xoshiro(1))
+        @test all(hvm.v[.!m] .== hv1.v[.!m])
+        @test all(abs.(hvm.v[m]) .≈ 1)
+        # `level` for FHRR uses its own ^-based method, not perturbation
+        @test level(FHRR(; D = 100), 5) isa Vector{<:FHRR}
     end
 
 end

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -32,8 +32,8 @@ Random.seed!(42)
                     @test bundle([hv1, hv2]).v == bundle([hv1, hv2]).v
                     hv3 = HV(; D = N)
                     @test bundle([hv1, hv2, hv3]).v == bundle([hv1, hv2, hv3]).v
-                    @test bundle([hv1, hv2]; rng = MersenneTwister(1)).v ==
-                        bundle([hv1, hv2]; rng = MersenneTwister(1)).v
+                    @test bundle([hv1, hv2]; rng = Xoshiro(1)).v ==
+                        bundle([hv1, hv2]; rng = Xoshiro(1)).v
                 end
             end
 
@@ -63,8 +63,8 @@ Random.seed!(42)
                 @test hv2.v[m] != hvp.v[m]
                 @test hv2.v[.!m] ≈ hvp.v[.!m]
 
-                @test perturbate(hv1, 0.1, rng = MersenneTwister(1)) == perturbate(hv1, 0.1, rng = MersenneTwister(1))
-                @test perturbate(hv1, 0.1, rng = MersenneTwister(1)) != perturbate(hv1, 0.1, rng = MersenneTwister(2))
+                @test perturbate(hv1, 0.1, rng = Xoshiro(1)) == perturbate(hv1, 0.1, rng = Xoshiro(1))
+                @test perturbate(hv1, 0.1, rng = Xoshiro(1)) != perturbate(hv1, 0.1, rng = Xoshiro(2))
             end
 
             # currently not yet a good way of evaluating these

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -86,6 +86,34 @@ Random.seed!(42)
         end
     end
 
+    @testset "unbind" begin
+        # XOR- and multiplication-based types: binding is self-inverse, roundtrip exact
+        for HV in [BinaryHV, BipolarHV, TernaryHV]
+            x, y = HV(:x), HV(:y)
+            @test unbind(bind(x, y), y) == x
+            @test (x * y) / y == x
+        end
+
+        # graded types: fuzzy unbinding is approximate — the recovered vector is
+        # closer to the original than to an unrelated one
+        for HV in [GradedHV, GradedBipolarHV]
+            x, y, z = HV(:x), HV(:y), HV(:z)
+            recovered = (x * y) / y
+            @test recovered isa HV
+            @test similarity(recovered, x) > similarity(recovered, z)
+        end
+
+        # FHRR: exact inverse via elementwise complex division
+        x, y = FHRR(:x), FHRR(:y)
+        @test collect((x * y) / y) ≈ collect(x)
+
+        # RealHV: real-valued MAP binding is not exactly invertible — explicit error
+        r1, r2 = RealHV(:x), RealHV(:y)
+        @test_throws ArgumentError unbind(r1, r2)
+        @test_throws ArgumentError r1 / r2
+        @test_throws "not exactly invertible" unbind(r1, r2)
+    end
+
     @testset "FHRR" begin
         hv1 = FHRR(; D = n)
         hv2 = FHRR(; D = n)

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -111,6 +111,18 @@ Random.seed!(42)
         @test isapprox(std(collect(normalize!(x * y))), 5; rtol = 0.1)
     end
 
+    # regression (TODO §1.6): shift! and the clamp!-based normalize! methods
+    # used to return the raw wrapped vector instead of the hypervector
+    @testset "in-place operations return the hypervector" begin
+        for HV in [BinaryHV, BipolarHV, TernaryHV, RealHV, GradedHV, GradedBipolarHV, FHRR]
+            hv = HV(; D = 20)
+            @test shift!(hv, 3) === hv
+            @test ρ!(hv) === hv
+            @test normalize!(hv) === hv
+            @test perturbate!(hv, 2) === hv
+        end
+    end
+
     @testset "unbind" begin
         # XOR- and multiplication-based types: binding is self-inverse, roundtrip exact
         for HV in [BinaryHV, BipolarHV, TernaryHV]

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -119,7 +119,11 @@ Random.seed!(42)
             @test shift!(hv, 3) === hv
             @test ρ!(hv) === hv
             @test normalize!(hv) === hv
+            # every perturbate! argument form: count, fraction, mask, indices
             @test perturbate!(hv, 2) === hv
+            @test perturbate!(hv, 0.1) === hv
+            @test perturbate!(hv, bitrand(length(hv))) === hv
+            @test perturbate!(hv, [1, 3]) === hv
         end
     end
 
@@ -173,7 +177,14 @@ Random.seed!(42)
         @test hvp isa FHRR
         @test all(abs.(hvp.v) .≈ 1)
         @test count(hvp.v .!= hv1.v) == 10   # exactly n positions resampled
-        @test perturbate(hv1, 0.2) isa FHRR
+        hvf = perturbate(hv1, 0.2)
+        @test hvf isa FHRR
+        @test all(abs.(hvf.v) .≈ 1)
+        # untouched positions carry similarity 1, resampled ones ≈ 0 in
+        # expectation, so similarity degrades to roughly 1 - p
+        hvbig = FHRR(; D = 10_000)
+        @test similarity(hvbig, perturbate(hvbig, 0.2)) ≈ 0.8 atol = 0.05
+        @test similarity(hvbig, perturbate(hvbig, 0.5)) ≈ 0.5 atol = 0.05
         m = bitrand(length(hv1))
         hvm = perturbate(hv1, m; rng = Xoshiro(1))
         @test all(hvm.v[.!m] .== hv1.v[.!m])

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -1,4 +1,5 @@
 using Random
+using Distributions
 
 Random.seed!(42)
 @testset "operations" begin
@@ -84,6 +85,30 @@ Random.seed!(42)
                 @test !(hv3 ≈ hv2)
             end
         end
+    end
+
+    # regression (TODO §1.5): bundle and bind used to silently replace a custom
+    # element distribution with the default, which changes normalize! numerics
+    @testset "bundle/bind preserve distr" begin
+        for (HV, d) in [
+                (RealHV, Normal(0, 5)),
+                (GradedHV, Beta(10, 2)),
+                (GradedBipolarHV, 2Beta(10, 2) - 1),
+            ]
+            x = HV(; D = 100, distr = d, seed = 1)
+            y = HV(; D = 100, distr = d, seed = 2)
+            @test bundle([x, y]).distr === x.distr
+            @test (x + y).distr === x.distr
+            @test bind(x, y).distr === x.distr
+            @test (x * y).distr === x.distr
+        end
+
+        # the observable consequence: normalize! rescales to the ORIGINAL spread —
+        # the metadata assertion alone would not catch this
+        x = RealHV(; D = 10_000, distr = Normal(0, 5), seed = 1)
+        y = RealHV(; D = 10_000, distr = Normal(0, 5), seed = 2)
+        @test isapprox(std(collect(normalize!(x + y))), 5; rtol = 0.1)
+        @test isapprox(std(collect(normalize!(x * y))), 5; rtol = 0.1)
     end
 
     @testset "unbind" begin

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -111,6 +111,24 @@ Random.seed!(42)
         @test isapprox(std(collect(normalize!(x * y))), 5; rtol = 0.1)
     end
 
+    # regression (TODO §1.5c): perturbate used to draw replacement elements from
+    # the TYPE-default distribution, ignoring the instance's `distr` — right
+    # metadata, wrong-distribution elements
+    @testset "perturbate resamples from hv.distr" begin
+        I = 1:5_000
+        x = RealHV(; D = 10_000, distr = Normal(0, 5), seed = 1)
+        xp = perturbate(x, I; rng = Xoshiro(1))
+        @test isapprox(std(xp.v[I]), 5; rtol = 0.1)
+
+        g = GradedHV(; D = 10_000, distr = Beta(10, 2), seed = 1)
+        gp = perturbate(g, I; rng = Xoshiro(1))
+        @test isapprox(mean(gp.v[I]), mean(Beta(10, 2)); rtol = 0.05)
+
+        gb = GradedBipolarHV(; D = 10_000, distr = 2Beta(10, 2) - 1, seed = 1)
+        gbp = perturbate(gb, I; rng = Xoshiro(1))
+        @test isapprox(mean(gbp.v[I]), mean(2Beta(10, 2) - 1); rtol = 0.1)
+    end
+
     # regression (TODO §1.6): shift! and the clamp!-based normalize! methods
     # used to return the raw wrapped vector instead of the hypervector
     @testset "in-place operations return the hypervector" begin

--- a/test/representations.jl
+++ b/test/representations.jl
@@ -1,0 +1,64 @@
+using Random: Xoshiro
+
+@testset "representations (plain display)" begin
+    # These tests are only valid while the UnicodePlots extension is NOT loaded;
+    # the rich-display tests run in a separate process (see ext_display.jl).
+    @test Base.get_extension(HyperdimensionalComputing, :UnicodePlotting) === nothing
+
+    plain(hv) = repr(MIME"text/plain"(), hv)
+
+    @testset "headers" begin
+        @test occursin(r"^100-element BinaryHV with \d+ true and \d+ false:", plain(BinaryHV(; D = 100)))
+        @test occursin(r"^100-element BipolarHV with \d+ positives and \d+ negatives:", plain(BipolarHV(; D = 100)))
+        @test occursin(r"^100-element TernaryHV\{Int64\} with \d+ positives, \d+ zeros, and \d+ negatives:", plain(TernaryHV(; D = 100)))
+        for HV in [RealHV, GradedHV, GradedBipolarHV, FHRR]
+            @test occursin(Regex("^100-element $HV.* with μ ± σ = "), plain(HV(; D = 100)))
+        end
+    end
+
+    @testset "elements and truncation" begin
+        hv = BipolarHV(; D = 19, seed = 1, rng = Xoshiro)
+
+        # untruncated: header plus one line per element, printed by Base
+        s = plain(hv)
+        @test length(split(s, '\n')) == 20
+        @test occursin(r"\n\s+-?1", s)
+
+        # Base's array machinery handles ⋮ truncation in limited displays
+        buf = IOBuffer()
+        show(IOContext(buf, :limit => true, :displaysize => (10, 80)), MIME"text/plain"(), hv)
+        slim = String(take!(buf))
+        @test occursin("19-element BipolarHV with", slim)
+        @test occursin("⋮", slim)
+    end
+
+    @testset "vectors of hypervectors" begin
+        vs = [BinaryHV(; D = 10) for _ in 1:3]
+        sv = repr(MIME"text/plain"(), vs)
+        @test occursin("3-element Vector{BinaryHV}:", sv)
+        @test count("-element BinaryHV with", sv) == 3
+    end
+
+    @testset "getindex" begin
+        # BipolarHV has a custom getindex mapping stored bits to ±1
+        hv = BipolarHV([true, false, true, true, false])
+        @test hv[1] === 1
+        @test hv[2] === -1
+        @test hv[end] === -1
+        @test hv[2:4] == [-1, 1, 1]
+        @test hv[2:4] isa Vector{Int}
+        @test hv[[1, 5]] == [1, -1]
+        @test hv[[true, false, true, false, false]] == [1, 1]
+
+        # uniform across all types: non-scalar indexing returns element values
+        # in a plain vector, never a new hypervector
+        for HV in [BinaryHV, BipolarHV, TernaryHV, RealHV, GradedHV, GradedBipolarHV, FHRR]
+            h = HV(; D = 20)
+            @test h[3] == collect(h)[3]
+            @test h[2:6] == collect(h)[2:6]
+            @test h[[1, 10, 20]] == collect(h)[[1, 10, 20]]
+            @test h[2:6] isa AbstractVector
+            @test !(h[2:6] isa AbstractHV)
+        end
+    end
+end

--- a/test/representations.jl
+++ b/test/representations.jl
@@ -8,19 +8,19 @@ using Random: Xoshiro
     plain(hv) = repr(MIME"text/plain"(), hv)
 
     @testset "headers" begin
-        @test occursin(r"^100-element BinaryHV with \d+ true and \d+ false:", plain(BinaryHV(; D=100)))
-        @test occursin(r"^100-element BipolarHV with \d+ positives and \d+ negatives:", plain(BipolarHV(; D=100)))
-        @test occursin(r"^100-element TernaryHV\{Int64\} with \d+ positives, \d+ zeros, and \d+ negatives:", plain(TernaryHV(; D=100)))
+        @test occursin(r"^100-element BinaryHV with \d+ true and \d+ false:", plain(BinaryHV(; D = 100)))
+        @test occursin(r"^100-element BipolarHV with \d+ positives and \d+ negatives:", plain(BipolarHV(; D = 100)))
+        @test occursin(r"^100-element TernaryHV\{Int64\} with \d+ positives, \d+ zeros, and \d+ negatives:", plain(TernaryHV(; D = 100)))
         for HV in [RealHV, GradedHV, GradedBipolarHV]
-            @test occursin(Regex("^100-element $HV.* with μ ± σ = "), plain(HV(; D=100)))
+            @test occursin(Regex("^100-element $HV.* with μ ± σ = "), plain(HV(; D = 100)))
         end
         # FHRR gets Base's plain header: mean/std of unit-circle complex numbers
         # carry no information, so no statistic is shown
-        @test occursin(r"^100-element FHRR\{ComplexF64\}:", plain(FHRR(; D=100)))
+        @test occursin(r"^100-element FHRR\{ComplexF64\}:", plain(FHRR(; D = 100)))
     end
 
     @testset "elements and truncation" begin
-        hv = BipolarHV(; D=19, rng=Xoshiro(1))
+        hv = BipolarHV(; D = 19, rng = Xoshiro(1))
 
         # untruncated: header plus one line per element, printed by Base
         s = plain(hv)
@@ -36,7 +36,7 @@ using Random: Xoshiro
     end
 
     @testset "vectors of hypervectors" begin
-        vs = [BinaryHV(; D=10) for _ in 1:3]
+        vs = [BinaryHV(; D = 10) for _ in 1:3]
         sv = repr(MIME"text/plain"(), vs)
         @test occursin("3-element Vector{BinaryHV}:", sv)
         @test count("-element BinaryHV with", sv) == 3
@@ -57,7 +57,7 @@ using Random: Xoshiro
         # uniform across all types: non-scalar indexing returns element values
         # in a plain vector, never a new hypervector
         for HV in [BinaryHV, BipolarHV, TernaryHV, RealHV, GradedHV, GradedBipolarHV, FHRR]
-            h = HV(; D=20)
+            h = HV(; D = 20)
             @test h[3] isa eltype(h)   # getindex must return the type parameter T
             @test h[3] == collect(h)[3]
             @test h[2:6] == collect(h)[2:6]

--- a/test/representations.jl
+++ b/test/representations.jl
@@ -17,7 +17,7 @@ using Random: Xoshiro
     end
 
     @testset "elements and truncation" begin
-        hv = BipolarHV(; D = 19, seed = 1, rng = Xoshiro)
+        hv = BipolarHV(; D = 19, rng = Xoshiro(1))
 
         # untruncated: header plus one line per element, printed by Base
         s = plain(hv)

--- a/test/representations.jl
+++ b/test/representations.jl
@@ -8,16 +8,19 @@ using Random: Xoshiro
     plain(hv) = repr(MIME"text/plain"(), hv)
 
     @testset "headers" begin
-        @test occursin(r"^100-element BinaryHV with \d+ true and \d+ false:", plain(BinaryHV(; D = 100)))
-        @test occursin(r"^100-element BipolarHV with \d+ positives and \d+ negatives:", plain(BipolarHV(; D = 100)))
-        @test occursin(r"^100-element TernaryHV\{Int64\} with \d+ positives, \d+ zeros, and \d+ negatives:", plain(TernaryHV(; D = 100)))
-        for HV in [RealHV, GradedHV, GradedBipolarHV, FHRR]
-            @test occursin(Regex("^100-element $HV.* with μ ± σ = "), plain(HV(; D = 100)))
+        @test occursin(r"^100-element BinaryHV with \d+ true and \d+ false:", plain(BinaryHV(; D=100)))
+        @test occursin(r"^100-element BipolarHV with \d+ positives and \d+ negatives:", plain(BipolarHV(; D=100)))
+        @test occursin(r"^100-element TernaryHV\{Int64\} with \d+ positives, \d+ zeros, and \d+ negatives:", plain(TernaryHV(; D=100)))
+        for HV in [RealHV, GradedHV, GradedBipolarHV]
+            @test occursin(Regex("^100-element $HV.* with μ ± σ = "), plain(HV(; D=100)))
         end
+        # FHRR gets Base's plain header: mean/std of unit-circle complex numbers
+        # carry no information, so no statistic is shown
+        @test occursin(r"^100-element FHRR\{ComplexF64\}:", plain(FHRR(; D=100)))
     end
 
     @testset "elements and truncation" begin
-        hv = BipolarHV(; D = 19, rng = Xoshiro(1))
+        hv = BipolarHV(; D=19, rng=Xoshiro(1))
 
         # untruncated: header plus one line per element, printed by Base
         s = plain(hv)
@@ -33,7 +36,7 @@ using Random: Xoshiro
     end
 
     @testset "vectors of hypervectors" begin
-        vs = [BinaryHV(; D = 10) for _ in 1:3]
+        vs = [BinaryHV(; D=10) for _ in 1:3]
         sv = repr(MIME"text/plain"(), vs)
         @test occursin("3-element Vector{BinaryHV}:", sv)
         @test count("-element BinaryHV with", sv) == 3
@@ -41,23 +44,25 @@ using Random: Xoshiro
 
     @testset "getindex" begin
         # BipolarHV has a custom getindex mapping stored bits to ±1
+        # by convention true => -1 and false => 1, so xor can be used for binding
         hv = BipolarHV([true, false, true, true, false])
-        @test hv[1] === 1
-        @test hv[2] === -1
-        @test hv[end] === -1
-        @test hv[2:4] == [-1, 1, 1]
+        @test hv[1] === -1
+        @test hv[2] === 1
+        @test hv[end] === 1
+        @test hv[2:4] == [1, -1, -1]
         @test hv[2:4] isa Vector{Int}
-        @test hv[[1, 5]] == [1, -1]
-        @test hv[[true, false, true, false, false]] == [1, 1]
+        @test hv[[1, 5]] == [-1, 1]
+        @test hv[[true, false, true, false, false]] == [-1, -1]
 
         # uniform across all types: non-scalar indexing returns element values
         # in a plain vector, never a new hypervector
         for HV in [BinaryHV, BipolarHV, TernaryHV, RealHV, GradedHV, GradedBipolarHV, FHRR]
-            h = HV(; D = 20)
+            h = HV(; D=20)
+            @test h[3] isa eltype(h)   # getindex must return the type parameter T
             @test h[3] == collect(h)[3]
             @test h[2:6] == collect(h)[2:6]
             @test h[[1, 10, 20]] == collect(h)[[1, 10, 20]]
-            @test h[2:6] isa AbstractVector
+            @test h[2:6] isa AbstractVector{eltype(h)}
             @test !(h[2:6] isa AbstractHV)
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,3 +5,13 @@ include("types.jl")
 include("operations.jl")
 include("encoding.jl")
 include("inference.jl")
+include("representations.jl")
+
+# The rich-display tests load UnicodePlots, which cannot be unloaded again,
+# while the plain-display tests above require the extension to be absent —
+# so the extension tests run in a fresh Julia process.
+@testset "UnicodePlots extension (separate process)" begin
+    script = joinpath(@__DIR__, "ext_display.jl")
+    cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) $script`
+    @test success(run(ignorestatus(cmd)))
+end

--- a/test/types.jl
+++ b/test/types.jl
@@ -48,6 +48,30 @@ using Logging: Logging
         @test !isequal(x, y)
         @test x != y
         @test !isequal(y, x)
+
+        # cross-type equality is strictly false, even when element values
+        # coincide numerically (true == 1): since the polarity flip, an all-true
+        # BinaryHV and an all-+1 BipolarHV have OPPOSITE stored bits
+        @test !isequal(BinaryHV(Bool[1, 0]), BipolarHV([1, -1]))
+        @test !isequal(BinaryHV(Bool[1, 1]), BipolarHV([1, 1]))
+        @test BinaryHV(Bool[1, 1]) != BipolarHV([1, 1])
+
+        # same family, different element type: compares by value
+        @test TernaryHV{Int8}(Int8[1, -1]) == TernaryHV{Int64}([1, -1])
+        @test isequal(TernaryHV{Int8}(Int8[1, -1]), TernaryHV{Int64}([1, -1]))
+
+        # hash/equality contract for every type — including BipolarHV, where
+        # storage and elements disagree; and against plain vectors, where
+        # elementwise isequal can be true and hashes must then match
+        for HV in [BinaryHV, BipolarHV, TernaryHV, RealHV, GradedHV, GradedBipolarHV, FHRR]
+            h = HV(; D = 20, seed = 5)
+            h2 = HV(; D = 20, seed = 5)
+            @test isequal(h, h2) && hash(h) == hash(h2)
+            @test isequal(h, collect(h)) && hash(h) == hash(collect(h))
+        end
+        p = BipolarHV([1, -1])
+        @test hash(p) == hash([1, -1])   # elements, not stored bits
+        @test hash(p) != hash(p.v)
     end
 
     @testset "BipolarHV" begin

--- a/test/types.jl
+++ b/test/types.jl
@@ -34,6 +34,22 @@ using Logging: Logging
         @test isapprox(similarity(BinaryHV(:cat), BinaryHV(:dog)), 1 / 3; atol = 0.05)
     end
 
+    # regression (TODO §1.8): hypervectors of different types used to compare
+    # `isequal` whenever their stored bits matched
+    @testset "equality and hashing" begin
+        x = BinaryHV(; D = 50, seed = 1)
+        @test x == BinaryHV(x.v)
+        @test isequal(x, BinaryHV(x.v))
+        @test hash(x) == hash(BinaryHV(x.v))
+
+        # same stored bits, different type: not equal
+        y = BipolarHV(; D = 50, seed = 1)   # same seed ⇒ identical stored bits
+        @test x.v == y.v                    # precondition for the regression
+        @test !isequal(x, y)
+        @test x != y
+        @test !isequal(y, x)
+    end
+
     @testset "BipolarHV" begin
         hdv = BipolarHV(; D = n)
 

--- a/test/types.jl
+++ b/test/types.jl
@@ -3,26 +3,31 @@ const s = :test
 const hash_s = hash(s)
 
 using Distributions
-using Logging: Logging
 
 @testset "types" begin
-    # The constructor convention shared by all hypervector types:
-    # `HV(this)` encodes an object deterministically via `hash(this)` — the
-    # positional argument is never a dimension; dimensionality is set with `D`.
-    @testset "constructor convention $HV" for HV in [
+    # `encode(HV, x)` is the canonical token path; `HV(x)` is shorthand for
+    # non-Number tokens, and Number arguments throw (irreducibly ambiguous
+    # with the dimensionality).
+    @testset "encode and constructor sugar $HV" for HV in [
             BinaryHV, BipolarHV, TernaryHV, RealHV,
             GradedHV, GradedBipolarHV, FHRR,
         ]
-        @test length(HV(42)) == 10_000  # 42 is a token, not a dimension
-        @test HV(42) == HV(42)          # deterministic per object
-        @test HV(:cat) == HV(:cat)
+        @test encode(HV, 42) == encode(HV, 42)      # deterministic per object
+        @test encode(HV, "cat") == encode(HV, "cat")
+        @test length(encode(HV, 42)) == 10_000
+        @test length(encode(HV, :cat; D = n)) == n
+        @test HV(:cat) == encode(HV, :cat)          # the sugar is genuinely sugar
+        @test HV("cat") == encode(HV, "cat")
         @test HV(:cat) != HV(:dog)
         @test length(HV(:cat; D = n)) == n
         @test length(HV(; D = n)) == n
 
-        # encoding an Integer warns that it is not a dimension; other tokens don't
-        @test_logs (:warn, r"never the dimensionality") match_mode = :any HV(42)
-        @test_logs min_level = Logging.Warn HV(:cat)
+        # Numbers throw, and the message teaches both alternatives
+        @test_throws ArgumentError HV(5)
+        @test_throws "D = 5" HV(5)
+        @test_throws "encode" HV(5)
+        @test_throws ArgumentError HV(2.5)
+        @test_throws ArgumentError HV(true)   # Bool is a Number
     end
 
     # Distinct objects give quasi-orthogonal hypervectors at the default D.
@@ -32,6 +37,56 @@ using Logging: Logging
         end
         # Jaccard similarity of random binary vectors has baseline ≈ 1/3
         @test isapprox(similarity(BinaryHV(:cat), BinaryHV(:dog)), 1 / 3; atol = 0.05)
+    end
+
+    # Data constructors: one meaning, validated per element domain.
+    @testset "data constructors and validation" begin
+        # the regression that motivated the encode interface: this used to
+        # silently token-encode into a 10,000-element hypervector
+        @test length(BinaryHV([1, 0])) == 2
+        @test collect(BinaryHV([1, 0])) == [true, false]
+        @test BinaryHV([1.0, 0.0]) == BinaryHV(Bool[1, 0])
+        @test_throws ArgumentError BinaryHV([1, 2])
+        @test_throws ArgumentError BinaryHV([0.5])
+
+        @test collect(BipolarHV([-1, 1])) == [-1, 1]
+        @test_throws ArgumentError BipolarHV([1, 0, -1])
+        @test_throws "TernaryHV" BipolarHV([1, 0, -1])   # zero points to TernaryHV
+        @test_throws ArgumentError BipolarHV([2.5, -1])  # no silent sign-taking
+
+        @test collect(TernaryHV([-1, 0, 1])) == [-1, 0, 1]
+        @test TernaryHV([-1.0, 0.0, 1.0]) == TernaryHV([-1, 0, 1])
+        @test_throws ArgumentError TernaryHV([2, 0])
+
+        @test RealHV([0.5, -3.7]) isa RealHV   # any real is fine
+
+        @test collect(GradedHV([0.0, 0.5, 1.0])) == [0.0, 0.5, 1.0]
+        @test_throws ArgumentError GradedHV([1.12])
+        @test_throws ArgumentError GradedHV([-0.2])
+
+        @test collect(GradedBipolarHV([-1.0, 0.5])) == [-1.0, 0.5]
+        @test_throws ArgumentError GradedBipolarHV([1.5])
+
+        @test FHRR([im, -1.0 + 0.0im]) isa FHRR
+        @test_throws ArgumentError FHRR([2.0 + 0.0im])   # not unit modulus
+
+        # tuples of reals read as data, like vectors (decided deliberately)
+        @test BipolarHV((1, -1)) == BipolarHV([1, -1])
+        @test length(BinaryHV((1, 0))) == 2
+
+        # arrays that are not valid element data throw instead of silently
+        # token-encoding; encode is the explicit escape hatch
+        @test_throws ArgumentError BinaryHV(["a", "b"])
+        @test encode(BinaryHV, ["a", "b"]) isa BinaryHV
+    end
+
+    # Construction and indexing agree for every type.
+    @testset "data round-trip $HV" for HV in [
+            BinaryHV, BipolarHV, TernaryHV, RealHV,
+            GradedHV, GradedBipolarHV, FHRR,
+        ]
+        x = HV(; D = 20, seed = 11)
+        @test HV(collect(x)) == x
     end
 
     # regression (TODO §1.8): hypervectors of different types used to compare
@@ -85,9 +140,8 @@ using Logging: Logging
         @test similar(hdv) isa BipolarHV
         @test sum(hdv) == sum(vi for vi in hdv)
         @test BipolarHV(s) == BipolarHV(; seed = hash_s)
-        # sign-based construction; Bool vectors are raw stored bits (true ↦ -1)
+        # strict ±1 data; Bool vectors are raw stored bits (true ↦ -1)
         @test collect(BipolarHV([-1, 1])) == [-1, 1]
-        @test collect(BipolarHV([-2.5, 0.1])) == [-1, 1]
         @test BipolarHV([-1, 1]) == BipolarHV([true, false])
         # zero has no bipolar state
         @test_throws ArgumentError BipolarHV([1, 0, -1])
@@ -161,9 +215,8 @@ using Logging: Logging
 
         @test GradedBipolarHV(; D = n, distr = 2Beta(10, 2) - 1) isa GradedBipolarHV
 
-        hv2 = GradedBipolarHV([0.1, 1.12, -0.2, -3.0])
-        normalize!(hv2)
-        @test all(-1 .≤ hv2 .≤ 1)
+        # out-of-range data is rejected, not clamped
+        @test_throws ArgumentError GradedBipolarHV([0.1, 1.12, -0.2, -3.0])
 
     end
 
@@ -182,9 +235,8 @@ using Logging: Logging
 
         @test GradedHV(; D = n, distr = Beta(10, 2)) isa GradedHV
 
-        hv2 = GradedHV([0.1, 1.12, -0.2, -3.0])
-        normalize!(hv2)
-        @test all(0 .≤ hv2 .≤ 1)
+        # out-of-range data is rejected, not clamped
+        @test_throws ArgumentError GradedHV([0.1, 1.12, -0.2, -3.0])
     end
 
     @testset "RealHV" begin

--- a/test/types.jl
+++ b/test/types.jl
@@ -25,6 +25,15 @@ using Logging: Logging
         @test_logs min_level = Logging.Warn HV(:cat)
     end
 
+    # Distinct objects give quasi-orthogonal hypervectors at the default D.
+    @testset "quasi-orthogonality of tokens" begin
+        for HV in [BipolarHV, RealHV, FHRR]  # cosine-type similarity: ≈ 0
+            @test abs(similarity(HV(:cat), HV(:dog))) < 0.05
+        end
+        # Jaccard similarity of random binary vectors has baseline ≈ 1/3
+        @test isapprox(similarity(BinaryHV(:cat), BinaryHV(:dog)), 1 / 3; atol = 0.05)
+    end
+
     @testset "BipolarHV" begin
         hdv = BipolarHV(; D = n)
 

--- a/test/types.jl
+++ b/test/types.jl
@@ -45,7 +45,32 @@ using Logging: Logging
         @test similar(hdv) isa BipolarHV
         @test sum(hdv) == sum(vi for vi in hdv)
         @test BipolarHV(s) == BipolarHV(; seed = hash_s)
-        @test BipolarHV([-1, 0, 1]) == BipolarHV([false, false, true])
+        # sign-based construction; Bool vectors are raw stored bits (true ↦ -1)
+        @test collect(BipolarHV([-1, 1])) == [-1, 1]
+        @test collect(BipolarHV([-2.5, 0.1])) == [-1, 1]
+        @test BipolarHV([-1, 1]) == BipolarHV([true, false])
+        # zero has no bipolar state
+        @test_throws ArgumentError BipolarHV([1, 0, -1])
+        @test_throws "no zero state" BipolarHV([1.0, 0.0])
+    end
+
+    # These tests are deliberately NOT polarity-blind: XOR self-inversion,
+    # quasi-orthogonality and cosine similarity are all invariant under flipping
+    # the bit↦element mapping, which is how the polarity bug survived a green
+    # suite. Each assertion here pins the mapping itself.
+    @testset "BipolarHV polarity" begin
+        x = BipolarHV(; D = 100, seed = 7)
+
+        # bind is self-inverse AND the identity is the all-+1 vector
+        @test all(collect(x * x) .== 1)
+
+        # construction and indexing agree: values round-trip through the sign constructor
+        @test BipolarHV(collect(x)) == x
+
+        # the summary header counts actual element values
+        s = summary(x)
+        @test occursin("$(count(==(1), collect(x))) positives", s)
+        @test occursin("$(count(==(-1), collect(x))) negatives", s)
     end
 
     @testset "BinaryHV" begin

--- a/test/types.jl
+++ b/test/types.jl
@@ -3,8 +3,28 @@ const s = :test
 const hash_s = hash(s)
 
 using Distributions
+using Logging: Logging
 
 @testset "types" begin
+    # The constructor convention shared by all hypervector types:
+    # `HV(this)` encodes an object deterministically via `hash(this)` — the
+    # positional argument is never a dimension; dimensionality is set with `D`.
+    @testset "constructor convention $HV" for HV in [
+            BinaryHV, BipolarHV, TernaryHV, RealHV,
+            GradedHV, GradedBipolarHV, FHRR,
+        ]
+        @test length(HV(42)) == 10_000  # 42 is a token, not a dimension
+        @test HV(42) == HV(42)          # deterministic per object
+        @test HV(:cat) == HV(:cat)
+        @test HV(:cat) != HV(:dog)
+        @test length(HV(:cat; D = n)) == n
+        @test length(HV(; D = n)) == n
+
+        # encoding an Integer warns that it is not a dimension; other tokens don't
+        @test_logs (:warn, r"never the dimensionality") match_mode = :any HV(42)
+        @test_logs min_level = Logging.Warn HV(:cat)
+    end
+
     @testset "BipolarHV" begin
         hdv = BipolarHV(; D = n)
 


### PR DESCRIPTION
Fixing all kinds of issues

1. Full repo audit → created TODO.md with every bug reproduced by execution, not just read (tests were 268/268 green while hiding all of them).
2. Constructor convention (HV(this; D) = token-encoding, never a dimension): documented canonically on AbstractHV and all 7 types, README Usage rewritten with real outputs, all encoding.jl example blocks regenerated, plus a one-time-per-session @warn for integer tokens — all locked in by a convention testset. *(The @warn was later superseded by a hard error — see item 12.)*
3. Docstring overhaul: all 8 type docstrings follow one template (signatures → identity → algebra → convention → indexing → examples → see-also → references), with 1–2 seeded jldoctests each — every output machine-generated via doctest(fix = true), never hand-written. bundle/bind/unbind got docstrings too. Doctests now run in CI (dedicated job + docs build).
4. Display/extension architecture: the extension now precompiles (single show in the package dispatching via get_extension), plain display uses per-type Base.summary + Base's array machinery, unicodeheatmap/unicodehistogram are exported and directly callable, FHRR gets an honest plain header instead of meaningless μ±σ, and StatsBase was dropped. Display finally has tests — plain and rich suites in separate Julia processes.
5. Indexing: scalar getindex returns T (verified for all 7 types); non-scalar returns a plain Vector, never a hypervector — decided, documented, tested. Settled the BinaryHV element question factually: {false, true} (Bool), displayed as 0/1.
6. RNG modernization: Xoshiro everywhere, default_rng(), rng takes instances, deterministic constructor is HV(this; D) with no rng — token construction now ~0.6 µs instead of allocating a 2.5 KB MersenneTwister state each call. All seeded outputs regenerated; quasi-orthogonality tests added.
7. Bugs found by verification, resolved by your decisions: unbind(::RealHV, ::RealHV) (was a raw MethodError) now throws an explicit ArgumentError pointing to similarity/FHRR/BipolarHV, with a full unbind testset across all types. Your BipolarHV bit-flip (true ↦ -1) is verified sound — bind-as-XOR is now exactly the ±1 product.
8. **BipolarHV polarity flip completed systematically**: audited all 25 sites touching the `.v` storage, each with an explicit verdict. Fixed: summary labels (were inverted), the data constructor (was negating input), stale doctests/README. Verified correct without change: bundle's majority vote (mapping-invariant), the bipolar dot formula, isapprox, hash/isequal, shift/perturbate. New polarity-locking tests are deliberately *not* polarity-blind (`all(x * x .== 1)`, construction/indexing round-trip, summary counts) — the original bug survived a green suite because XOR-self-inversion and cosine are invariant under the flip. Tie-break outcome change noted under #15.
9. **Six more bugs fixed, one commit each, every one reproduced by execution first and locked by a regression test**: perturbate on FHRR (now resamples phases, stays on the unit circle), instance-path decodelevel/convertlevel (kwarg mis-dispatch), bundle/bind silently dropping custom `distr` (locked by the *numerical* consequence: normalize! rescales to the original spread), in-place ops returning raw vectors (shift! **and** the three clamp!-based normalize! methods; all perturbate! argument forms locked), `const δ`, and cross-type isequal/hash. Adjacent bug found and flagged, not fixed: instance-path convertlevel builds encoder and decoder over *different* random ladders — measured decode(encode(x)) error up to 1.0 (TODO §1.4b, retired properly by the encoder follow-up below).
10. **Cross-type equality is now strictly false**: Julia's numeric `true == 1` let an all-true BinaryHV equal an all-+1 BipolarHV even though their stored bits are opposite since the flip. `==`/`isequal` between different hypervector types return false; same-family different-parameter (TernaryHV{Int8} vs {Int64}) compares by value; hashing stays element-based because `isequal(hv, ::Vector)` can legitimately be true and the hash/equality contract must hold against plain vectors too. All locked by tests.
11. **perturbate resampled from the TYPE-default distribution instead of `hv.distr`** (found in the §1.5 pattern sweep — right metadata, wrong-distribution elements; measured std ≈ 1 where 5 was configured). Fixed with instance `eldist` methods and locked by resampled-statistics tests.
12. **The `encode` interface** (design change): the package now has an explicit layer taxonomy — primitives (operations.jl) → combinators (encoding.jl, unchanged) → encoders (encode.jl, new: raw data in, hypervector out). `encode(HV, x)` is the canonical deterministic token path; `HV(x)` is sugar for it. Constructors have one meaning each: `HV(n::Number)` throws an ArgumentError naming both alternatives (`D = n` / `encode(HV, n)`) — replacing the @warn from item 2 — and data constructors are widened to `AbstractVector{<:Real}` with per-type element validation (BinaryHV {0,1} — `BinaryHV([1, 0])` is finally a 2-element hypervector, not a silent 10,000-dim hash; BipolarHV strictly ±1 with zero pointing to TernaryHV; TernaryHV {-1,0,+1} with permissive inner constructors for operation results; graded ranges rejected instead of silently clamped; FHRR unit-modulus). Tuples of reals read as data. Sequence strategies dispatch on `AbstractEncoding`: **KMer(k) resolves #53** (windows as atomic hashed tokens) and is deliberately distinct from NGram(n) (symbol-level shift-binding via ngrams); plus Sequence() and BagOfSymbols(). Extension point: one struct + one encode method. The new validation immediately caught two latent wrongs: a test using the old trap idiom and a tutorial example constructing a TernaryHV from 0:9.
13. Tracking: TODO.md and CLAUDE.md document the architecture, every decision, and the flagged follow-ups.

**Test suite: 268 → 669 assertions** (plus 37 extension tests in a separate process and CI-enforced doctests). **Breaking changes**: seeded RNG streams (MersenneTwister → Xoshiro), BipolarHV polarity + strict data validation, graded types reject instead of clamp, cross-type equality, numeric constructor tokens throw.

## Follow-ups (tracked in TODO.md)

- Stateful encoders as an `AbstractEncoder{HV}` hierarchy (`RandomProjection`, `LevelEncoder`) with encode/decode — retires §1.4b properly; `encode`'s first-arg slot is reserved for it.
- Classification workflow (`train`/`predict`) — the JuliaCon demo.
- Registration track: Aqua.jl + the three §2 API decisions (Base.bind, `similar`, `normalize` clash), CI matrix, coverage, CompatHelper/TagBot → register in General (#9).
- Docs polish: README badge, docs restructure (#32), intro-tutorial ngrams example (#36).
